### PR TITLE
ci: add pylint check and reformat code to pass

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,17 @@ jobs:
           # TODO: Expand our CI run to include the client/server tests too
           # https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py/issues/10
           python -m pytest test/test_filesystem.py test/test_resources.py test/test_typesystem.py
+
+  lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install linters
+        run: |
+          python -m pip install --upgrade pip
+          pip install pylint
+
+      - name: Run pylint
+        run: |
+          pylint ctakesclient/ scripts/* test/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+/ctakesclient.egg-info/
 /.idea/
 /dist/
 /venv/

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,436 @@
+# Below is a copy of Google's pylintrc, with the following modifications:
+# - indent-string changed to 4 spaces (the shipped version of this config
+#   file has 2 because that's what Google uses internally, despite the
+#   public description of their style guide using 4)
+#
+# BELOW THIS LINE IS A COPY OF https://google.github.io/styleguide/pylintrc
+
+# This Pylint rcfile contains a best-effort configuration to uphold the
+# best-practices and style described in the Google Python style guide:
+#   https://google.github.io/styleguide/pyguide.html
+#
+# Its canonical open-source location is:
+#   https://google.github.io/styleguide/pylintrc
+
+[MASTER]
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=third_party
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=4
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=abstract-method,
+        apply-builtin,
+        arguments-differ,
+        attribute-defined-outside-init,
+        backtick,
+        bad-option-value,
+        basestring-builtin,
+        buffer-builtin,
+        c-extension-no-member,
+        consider-using-enumerate,
+        cmp-builtin,
+        cmp-method,
+        coerce-builtin,
+        coerce-method,
+        delslice-method,
+        div-method,
+        duplicate-code,
+        eq-without-hash,
+        execfile-builtin,
+        file-builtin,
+        filter-builtin-not-iterating,
+        fixme,
+        getslice-method,
+        global-statement,
+        hex-method,
+        idiv-method,
+        implicit-str-concat,
+        import-error,
+        import-self,
+        import-star-module-level,
+        inconsistent-return-statements,
+        input-builtin,
+        intern-builtin,
+        invalid-str-codec,
+        locally-disabled,
+        long-builtin,
+        long-suffix,
+        map-builtin-not-iterating,
+        misplaced-comparison-constant,
+        missing-function-docstring,
+        metaclass-assignment,
+        next-method-called,
+        next-method-defined,
+        no-absolute-import,
+        no-else-break,
+        no-else-continue,
+        no-else-raise,
+        no-else-return,
+        no-init,  # added
+        no-member,
+        no-name-in-module,
+        no-self-use,
+        nonzero-method,
+        oct-method,
+        old-division,
+        old-ne-operator,
+        old-octal-literal,
+        old-raise-syntax,
+        parameter-unpacking,
+        print-statement,
+        raising-string,
+        range-builtin-not-iterating,
+        raw_input-builtin,
+        rdiv-method,
+        reduce-builtin,
+        relative-import,
+        reload-builtin,
+        round-builtin,
+        setslice-method,
+        signature-differs,
+        standarderror-builtin,
+        suppressed-message,
+        sys-max-int,
+        too-few-public-methods,
+        too-many-ancestors,
+        too-many-arguments,
+        too-many-boolean-expressions,
+        too-many-branches,
+        too-many-instance-attributes,
+        too-many-locals,
+        too-many-nested-blocks,
+        too-many-public-methods,
+        too-many-return-statements,
+        too-many-statements,
+        trailing-newlines,
+        unichr-builtin,
+        unicode-builtin,
+        unnecessary-pass,
+        unpacking-in-except,
+        useless-else-on-loop,
+        useless-object-inheritance,
+        useless-suppression,
+        using-cmp-argument,
+        wrong-import-order,
+        xrange-builtin,
+        zip-builtin-not-iterating,
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=main,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty,cached_property.cached_property,cached_property.threaded_cached_property,cached_property.cached_property_with_ttl,cached_property.threaded_cached_property_with_ttl
+
+# Regular expression matching correct function names
+function-rgx=^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct constant names
+const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct attribute names
+attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
+
+# Regular expression matching correct argument names
+argument-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=^_?[A-Z][a-zA-Z0-9]*$
+
+# Regular expression matching correct module names
+module-rgx=^(_?[a-z][a-z0-9_]*|__init__)$
+
+# Regular expression matching correct method names
+method-rgx=(?x)^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase|tearDownTestCase|setupSelf|tearDownClass|setUpClass|(test|assert)_*[A-Z0-9][a-zA-Z0-9_]*|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9_]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=(__.*__|main|test.*|.*test|.*Test)$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=10
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager,contextlib2.contextmanager
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# TODO(https://github.com/PyCQA/pylint/issues/3352): Direct pylint to exempt
+# lines made too long by directives to pytype.
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=(?x)(
+  ^\s*(\#\ )?<?https?://\S+>?$|
+  ^\s*(from\s+\S+\s+)?import\s+.+$)
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=yes
+
+# Maximum number of lines in a module
+max-module-lines=99999
+
+# String used as indentation unit.  The internal Google style guide mandates 2
+# spaces.  Google's externaly-published style guide says 4, consistent with
+# PEP 8.  Here, we use 2 spaces, for conformity with many open-sourced Google
+# projects (like TensorFlow).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=TODO
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=yes
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=^\*{0,2}(_$|unused_|dummy_)
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six,six.moves,past.builtins,future.builtins,functools
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging,absl.logging,tensorflow.io.logging
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec,
+                   sets
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant, absl
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls,
+                            class_
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=StandardError,
+                       Exception,
+                       BaseException

--- a/ctakesclient/__init__.py
+++ b/ctakesclient/__init__.py
@@ -1,3 +1,5 @@
+"""Public API"""
+
 from . import typesystem
 from . import filesystem
 from . import client

--- a/ctakesclient/client.py
+++ b/ctakesclient/client.py
@@ -1,20 +1,18 @@
-from typing import List
+"""HTTP client for medical language"""
+
 import os
 import logging
 import requests
-from ctakesclient.exceptions import TypeSystemError, ClientError
-from ctakesclient.typesystem import Span, Polarity, CtakesJSON
-from ctakesclient.typesystem import UmlsTypeMention, UmlsConcept, MatchText
+from ctakesclient.typesystem import CtakesJSON
 
-#######################################################################################################################
-#
-# HTTP Client for Medical Language
+###############################################################################
 #
 # https://github.com/Machine-Learning-for-Medical-Language/ctakes-covid-container
 #
 # https://github.com/Machine-Learning-for-Medical-Language/cnlp_transformers#negation-api
 #
-#######################################################################################################################
+###############################################################################
+
 
 def get_url_ctakes_rest() -> str:
     """
@@ -22,18 +20,23 @@ def get_url_ctakes_rest() -> str:
 
     :return: URL_CTAKES_REST env variable or default using localhost
     """
-    return os.environ.get('URL_CTAKES_REST', 'http://localhost:8080/ctakes-web-rest/service/analyze')
+    return os.environ.get(
+        'URL_CTAKES_REST',
+        'http://localhost:8080/ctakes-web-rest/service/analyze')
 
-def post(sentence:str, url=get_url_ctakes_rest()) -> dict:
+
+def post(sentence: str, url=get_url_ctakes_rest()) -> dict:
     """
     :param sentence: clinical text to send to cTAKES
     :param url: cTAKES REST server fully qualified path
     :return:
     """
     logging.debug(url)
-    return requests.post(url, data=sentence).json()
+    # TODO: consider exposing a pass-through timeout parameter
+    return requests.post(url, data=sentence).json()  # pylint: disable=missing-timeout
 
-def extract(sentence:str, url=get_url_ctakes_rest()) -> CtakesJSON:
+
+def extract(sentence: str, url=get_url_ctakes_rest()) -> CtakesJSON:
     """
     :param sentence: clinical text to send to cTAKES
     :param url: cTAKES REST server fully qualified path

--- a/ctakesclient/exceptions.py
+++ b/ctakesclient/exceptions.py
@@ -1,28 +1,34 @@
-#######################################################################################################################
-#
-# Error Types
-#
-#######################################################################################################################
+"""Error types"""
+
+
 class CtakesError(Exception):
     """
     Package level error
     """
     pass
+
+
 class ClientError(CtakesError):
     """
     HTTP request/response problem with server
     """
     pass
+
+
 class TypeSystemError(CtakesError):
     """
     Ctakes Type System, specific to cTAKES REST and cNLP transformer APIs
     """
     pass
+
+
 class FileError(CtakesError):
     """
     File problems reading/writing/serializing
     """
     pass
+
+
 class BSVError(FileError):
     """
     Bar|Separated|Values error

--- a/ctakesclient/filesystem.py
+++ b/ctakesclient/filesystem.py
@@ -1,20 +1,30 @@
+"""File loading and parsing"""
+
 from typing import List
 import logging
 import json
 from ctakesclient.exceptions import BSVError
 
-#######################################################################################################################
+###############################################################################
 # Filetype: *.bsv
 #
 # BSV = Bar|Separated|Value
 #
-#######################################################################################################################
+###############################################################################
+
 
 class BsvConcept:
     """
     BSV flat file of UMLS Concept
     """
-    def __init__(self, cui=None, tui=None, code=None, vocab=None, text=None, pref=None):
+
+    def __init__(self,
+                 cui=None,
+                 tui=None,
+                 code=None,
+                 vocab=None,
+                 text=None,
+                 pref=None):
         """
         BSV file format =
         CUI|TUI|CODE|VOCAB|TXT|PREF
@@ -24,9 +34,11 @@ class BsvConcept:
 
         :param cui: CUI from UMLS or NA for "identified annotation"
         :param code: CODE or "identified annotation" code
-        :param vocab: SNOMEDCT_US or other vocab https://www.nlm.nih.gov/research/umls/sourcereleasedocs/index.html
+        :param vocab: SNOMEDCT_US or other vocab
+                      https://www.nlm.nih.gov/research/umls/sourcereleasedocs/index.html
         :param text: string representation
-        :param pref: preferred terms https://www.nlm.nih.gov/research/umls/new_users/online_learning/Meta_004.html
+        :param pref: preferred terms
+                     https://www.nlm.nih.gov/research/umls/new_users/online_learning/Meta_004.html
         """
         self.cui = cui
         self.tui = tui
@@ -64,17 +76,19 @@ class BsvConcept:
         self.pref = source[5]
 
     def to_bsv(self):
-        return f'{self.cui}|{self.tui}|{self.code}|{self.vocab}|{self.text}|{self.pref}'
+        return (f'{self.cui}|{self.tui}|{self.code}|{self.vocab}|'
+                f'{self.text}|{self.pref}')
 
     def __str__(self):
         return self.to_bsv()
 
-#######################################################################################################################
+
+###############################################################################
 # Filetype: *.bsv
 #
 # BSV Semantic Types
 #
-#######################################################################################################################
+###############################################################################
 class BsvSemanticType:
     """
     BSV file of Unified Medical Language System Groups
@@ -83,7 +97,12 @@ class BsvSemanticType:
     TODO: cTAKES also has a Mentions grouping of UMLS Types
     https://lhncbc.nlm.nih.gov/ii/tools/MetaMap/documentation/SemanticTypesAndGroups.html
     """
-    def __init__(self, group_id=None, group_label=None, tui=None, tui_label=None):
+
+    def __init__(self,
+                 group_id=None,
+                 group_label=None,
+                 tui=None,
+                 tui_label=None):
         """
         :param group_id: UMLS Semantic Group Abbreviation
         :param group_label: UMLS Semantic Group Label (longer than abbreviation)
@@ -125,61 +144,67 @@ class BsvSemanticType:
     def __str__(self):
         return self.to_bsv()
 
-#######################################################################################################################
+
+###############################################################################
 # FUNCTIONS for file handling
 #
 # File Common Helper functions with INFO logging
 #
-#######################################################################################################################
+###############################################################################
 def list_bsv(filename, class_bsv) -> list:
     """
     :param filename: BSV filename to parse
     :param class_bsv: what type of BSV resource to construct
     :return: list of BSV entries
     """
-    entries = list()
+    entries = []
     for line in read_text_lines(filename):
         if line.startswith('#'):
-            logging.info(f'found header : {line} : {filename}')
+            logging.info('found header : %s : %s', line, filename)
         else:
             parsed = class_bsv()
             parsed.from_bsv(line.strip())
             entries.append(parsed)
     return entries
 
+
 def list_bsv_semantics(filename) -> List[BsvSemanticType]:
     return list_bsv(filename, BsvSemanticType)
 
+
 def list_bsv_concept(filename) -> List[BsvConcept]:
     return list_bsv(filename, BsvConcept)
+
 
 def map_cui_pref(filename) -> dict:
     """
     :param filename: see BSV file, where rows are CUI|TUI|CODE|VOCAB|TXT|PREF
     :return: map of {cui:text} labels
     """
-    cui_map = dict()
+    cui_map = {}
     for bsv in list_bsv_concept(filename):
         cui_map[bsv.cui] = bsv.pref.strip()
     return cui_map
 
-#######################################################################################################################
+
+###############################################################################
 #
 # File Common Helper functions with INFO logging
 #
-#######################################################################################################################
+###############################################################################
 def read_text(filename) -> str:
-    logging.info(f'read_text({filename})')
-    with open(filename, 'r') as fp:
+    logging.info('read_text(%s)', filename)
+    with open(filename, 'r', encoding='utf-8') as fp:
         return fp.read()
 
+
 def read_text_lines(filename) -> List[str]:
-    logging.info(f'read_text({filename})')
-    with open(filename, 'r') as fp:
+    logging.info('read_text_lines(%s)', filename)
+    with open(filename, 'r', encoding='utf-8') as fp:
         return fp.readlines()
 
-def read_json(filename) -> dict:
-    logging.info(f'read_json({filename})')
-    with open(filename, 'r') as fp:
-        return json.load(fp)
 
+def read_json(filename) -> dict:
+    logging.info('read_json(%s)', filename)
+    with open(filename, 'r', encoding='utf-8') as fp:
+        return json.load(fp)

--- a/ctakesclient/transformer.py
+++ b/ctakesclient/transformer.py
@@ -1,17 +1,17 @@
+"""HTTP client for medical language"""
+
 from typing import List
 import os
-import logging
 import requests
 from ctakesclient.exceptions import ClientError
-from ctakesclient.typesystem import Span, Polarity
+from ctakesclient.typesystem import Polarity
 
-#######################################################################################################################
-#
-# HTTP Client for Medical Language
+###############################################################################
 #
 # https://github.com/Machine-Learning-for-Medical-Language/cnlp_transformers#negation-api
 #
-#######################################################################################################################
+###############################################################################
+
 
 def get_url_cnlp_negation() -> str:
     """
@@ -19,9 +19,12 @@ def get_url_cnlp_negation() -> str:
 
     :return: CTAKES_URL_NEGATION env variable or default using localhost
     """
-    return os.environ.get('URL_CNLP_NEGATION', 'http://localhost:8000/negation/process')
+    return os.environ.get('URL_CNLP_NEGATION',
+                          'http://localhost:8000/negation/process')
 
-def list_polarity(sentence: str, spans: list, url=get_url_cnlp_negation()) -> List[Polarity]:
+
+def list_polarity(sentence: str, spans: list,
+                  url=get_url_cnlp_negation()) -> List[Polarity]:
     """
     :param sentence: clinical text to send to cTAKES
     :param spans: list of spans where each span is a tuple of (begin,end)
@@ -30,8 +33,9 @@ def list_polarity(sentence: str, spans: list, url=get_url_cnlp_negation()) -> Li
     """
     doc = {'doc_text': sentence, 'entities': spans}
 
-    response = requests.post(url=url, json=doc).json()
-    polarities = list()
+    # TODO: consider exposing a pass-through timeout parameter
+    response = requests.post(url=url, json=doc).json()  # pylint: disable=missing-timeout
+    polarities = []
 
     for status in response['statuses']:
         # NOT negated (double negative)
@@ -44,11 +48,14 @@ def list_polarity(sentence: str, spans: list, url=get_url_cnlp_negation()) -> Li
             raise ClientError(f'negate-api unknown {status}, url= {url}')
 
     if len(spans) != len(polarities):
-        raise ClientError(f'Number of Spans and Polarities did not match: {spans}, {polarities}')
+        raise ClientError('Number of Spans and Polarities did not match: '
+                          f'{spans}, {polarities}')
 
     return polarities
 
-def map_polarity(sentence: str, spans: list, url=get_url_cnlp_negation()) -> dict:
+
+def map_polarity(sentence: str, spans: list,
+                 url=get_url_cnlp_negation()) -> dict:
     """
     :param sentence: clinical text to send to cTAKES
     :param spans: list of spans where each span is a tuple of (begin,end)
@@ -56,7 +63,7 @@ def map_polarity(sentence: str, spans: list, url=get_url_cnlp_negation()) -> dic
     :return: Map of Polarity key=span, value=polarity
     """
     polarities = list_polarity(sentence, spans, url)
-    mapped = dict()
+    mapped = {}
 
     for span, polarity in zip(spans, polarities):
         mapped[span] = polarity

--- a/scripts/polarity-diff-report
+++ b/scripts/polarity-diff-report
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# pylint: disable=invalid-name
+"""Generates and shows polarity difference reports between cTAKES and cNLP"""
 
 import argparse
 import csv
@@ -29,7 +31,7 @@ def compare_note_polarity(text: str):
 
     polarities_cnlp = ctakesclient.transformer.list_polarity(text, spans)
     if len(matches) != len(polarities_cnlp):
-        raise JSONDecodeError('Polarity lists had different lengths!')
+        raise JSONDecodeError('Polarity lists had different lengths!', text, 0)
 
     differing = []
     for i in range(len(matches)):
@@ -51,7 +53,7 @@ def calculate(parser, args):
               file=sys.stderr)
         sys.exit(1)
 
-    print("Processing...")
+    print('Processing...')
 
     if args.resume:
         mode = 'r+'
@@ -63,11 +65,12 @@ def calculate(parser, args):
         start_processing_after = None
         if args.resume:
             # Read until the end
+            line = None
             for line in output_file:
                 pass
             if line:
                 start_processing_after = json.loads(line)['instance_num']
-                print(f"Resuming after instance id {start_processing_after}...")
+                print(f'Resuming after instance id {start_processing_after}...')
 
         with open(args.notes_path, 'r', encoding='utf8') as notes_file:
             notes = csv.DictReader(notes_file)
@@ -80,7 +83,8 @@ def calculate(parser, args):
                 note_tic = time.perf_counter()
                 try:
                     error = None
-                    differences = compare_note_polarity(note['OBSERVATION_BLOB'])
+                    differences = compare_note_polarity(
+                        note['OBSERVATION_BLOB'])
                 except JSONDecodeError as e:
                     error = str(e)
                     differences = []
@@ -96,12 +100,12 @@ def calculate(parser, args):
                 output_file.flush()  # just in case we want to stop halfway
                 note_toc = time.perf_counter()
 
-                print(f"Processed note {count} "
+                print(f'Processed note {count} '
                       f"(instance id: {note['INSTANCE_NUM']}) "
-                      f"in {note_toc - note_tic:.0f} seconds")
+                      f'in {note_toc - note_tic:.0f} seconds')
     total_toc = time.perf_counter()
 
-    print(f"Total time spent: {total_toc - total_tic:.0f} seconds")
+    print(f'Total time spent: {total_toc - total_tic:.0f} seconds')
 
 
 def note_context(text: str, match: MatchText) -> str:
@@ -114,13 +118,13 @@ def note_context(text: str, match: MatchText) -> str:
 def show_note(args, note):
     if args.diff:
         if len(note['differences']) < args.diff:
-            print("Not enough differences in the specified note! "
+            print('Not enough differences in the specified note! '
                   f"Only {len(note['differences'])}")
             sys.exit(1)
 
     if args.show_full:
         print(note['note'])
-        print("\n\n\n==================================")
+        print('\n\n\n==================================')
 
     if note['error']:
         print('ERROR:', note['error'])
@@ -131,10 +135,11 @@ def show_note(args, note):
 
         m = MatchText(source=diff['match'])
         cnlp = diff['cnlp_polarity']
-        print(f"\n=== differing span {count} ({m.begin}-{m.end}): {m.type.value}: '{m.text}' ===")
-        print("cTAKES says:", m.polarity.name)
-        print("cNLP says  :", Polarity(cnlp).name)
-        print("Context:", note_context(note['note'], m))
+        print(f'\n=== differing span {count} ({m.begin}-{m.end}): '
+              f"{m.type.value}: '{m.text}' ===")
+        print('cTAKES says:', m.polarity.name)
+        print('cNLP says  :', Polarity(cnlp).name)
+        print('Context:', note_context(note['note'], m))
 
 
 def report(parser, args):
@@ -174,7 +179,8 @@ def main():
 
     calculate_parser = subparsers.add_parser('calculate')
     calculate_parser.add_argument('notes_path', metavar='notes.csv')
-    calculate_parser.add_argument('-c', '--continue', dest='resume', action='store_true')
+    calculate_parser.add_argument('-c', '--continue', dest='resume',
+                                  action='store_true')
     # TODO: offer an --update option (and/or a --replace with a danger prompt)
     calculate_parser.set_defaults(func=calculate)
 

--- a/test/test_client_covid_symptoms.py
+++ b/test/test_client_covid_symptoms.py
@@ -1,36 +1,41 @@
-import logging
-import os
+"""Tests based on covid symptoms"""
+
 import json
 import unittest
 import ctakesclient
-from test.test_resources import PathResource, LoadResource
+from .test_resources import LoadResource
+
 
 def pretty(result: dict):
     print(json.dumps(result, indent=4))
 
-@unittest.skip("https://github.com/comorbidity/ctakes-client-python/issues/6")
+
+# pylint: disable-next=line-too-long
+@unittest.skip('https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py/issues/7')
 class TestCtakesClient(unittest.TestCase):
+    """Test case for ctakes client extracting covid symptoms"""
 
     def test_covid_symptoms_medical_synonyms(self):
         """
         Test if COVID19 symptom synonyms are mapped in the BSV dictionary.
         https://github.com/Machine-Learning-for-Medical-Language/ctakes-covid-container/blob/main/covid.bsv
         """
-        expected = {'SOB': 'Shortness Of Breath',
-                    'HA': 'Headache',
-                    'Myalgias': 'Muscle aches and pain',
-                    'Chills': 'Fever or chills',
-                    'Post-tussive': 'after Coughing',
-                    'tussive':'related to Coughing',
-                    'Pharyngitis':'sore throat',
-                    'Odynophagia': 'sore throat',
-                    'Loss of taste': 'Anosmia',
-                    'Loss of smell': 'Anosmia',
-                    'Tired': 'Fatigue',
-                    }
+        expected = {
+            'SOB': 'Shortness Of Breath',
+            'HA': 'Headache',
+            'Myalgias': 'Muscle aches and pain',
+            'Chills': 'Fever or chills',
+            'Post-tussive': 'after Coughing',
+            'tussive':'related to Coughing',
+            'Pharyngitis':'sore throat',
+            'Odynophagia': 'sore throat',
+            'Loss of taste': 'Anosmia',
+            'Loss of smell': 'Anosmia',
+            'Tired': 'Fatigue',
+        }
 
-        actual = list()
-        for symptom in expected.keys():
+        actual = []
+        for symptom in expected:
             found = ctakesclient.client.extract(symptom).list_match_text()
             if symptom in found:
                 actual.append(symptom)
@@ -45,35 +50,24 @@ class TestCtakesClient(unittest.TestCase):
         https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html
 
         Test if every COVID symptom is found in server dictionary.
-        https://github.com/comorbidity/ctakes-client-python/blob/main/resources/covid_symptoms.bsv -->
+        https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py/blob/main/test/resources/covid_symptoms.bsv
+        -->
         https://github.com/Machine-Learning-for-Medical-Language/ctakes-covid-container/blob/main/covid.bsv
         """
-        for bsv in LoadResource.covid_symptoms.value:
+        for bsv in LoadResource.COVID_SYMPTOMS.value:
             ner = ctakesclient.client.extract(bsv.text)
 
-            cui_list = list()
-            text_list = list()
+            cui_list = []
+            text_list = []
 
             for match in ner.list_sign_symptom():
                 text_list.append(match.text)
                 for concept in match.conceptAttributes:
                     cui_list.append(concept.cui)
 
-            if bsv.text not in text_list:
-                err = f'{bsv.cui}\t\t ** cui NOT found in {set(cui_list)} ** \t{str(bsv)}'
-                logging.error(err)
+            self.assertIn(bsv.text, text_list)
+            self.assertIn(bsv.cui, cui_list)
 
-                self.assertTrue(bsv.text in text_list, err)
-
-            if bsv.cui not in cui_list:
-                err = f'{bsv.cui}\t\t ** cui NOT found in {set(cui_list)} ** \t{str(bsv)}'
-                logging.error(err)
-
-                self.assertTrue(bsv.cui in cui_list, err)
 
 if __name__ == '__main__':
     unittest.main()
-
-
-
-

--- a/test/test_client_ctakes_rest_server.py
+++ b/test/test_client_ctakes_rest_server.py
@@ -1,26 +1,30 @@
-import logging
-import json
+"""Tests for the cTAKES REST API"""
+
 import unittest
 import ctakesclient
-from test.test_resources import PathResource, LoadResource
+from .test_resources import LoadResource
 
 class TestClientCtakesRestServer(unittest.TestCase):
+    """Test case for REST requests"""
 
     def test_physician_note(self):
         """
         Test calling REST server returns JSON that matches expected.
-        Strong typing (Polarity, MatchText, UmlsConcept) enforced during serialization.
+        Strong typing (Polarity, MatchText, UmlsConcept) enforced during
+        serialization.
         """
-        physician_note = LoadResource.physician_note_text.value
-        expected = LoadResource.physician_note_json.value
+        physician_note = LoadResource.PHYSICIAN_NOTE_TEXT.value
+        expected = LoadResource.PHYSICIAN_NOTE_JSON.value
 
         actual1 = ctakesclient.client.extract(physician_note).as_json()
         actual2 = ctakesclient.client.extract(physician_note).as_json()
 
         unittest.TestCase.maxDiff = None
 
-        self.assertDictEqual(expected, actual1, 'JSON did not match round trip serialization')
-        self.assertDictEqual(actual1, actual2, 'calling service twice produces same results')
+        self.assertDictEqual(expected, actual1,
+                             'JSON did not match round trip serialization')
+        self.assertDictEqual(actual1, actual2,
+                             'calling service twice produces same results')
 
 
 if __name__ == '__main__':

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -1,33 +1,41 @@
+"""Tests for the filesystem module"""
+
 import unittest
 
 import ctakesclient
-from test.test_resources import PathResource
+from .test_resources import PathResource
+
 
 class TestCovidSymptomsBSV(unittest.TestCase):
+    """Test case for covid symptoms loaded from bsv"""
 
     def test_covid_symptom_concepts(self):
         """
         Symptoms of COVID-19
         https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html
         """
-        for bsv in ctakesclient.filesystem.list_bsv_concept(PathResource.covid_symptoms.value):
+        for bsv in ctakesclient.filesystem.list_bsv_concept(
+                PathResource.COVID_SYMPTOMS.value):
             self.assertTrue(bsv.cui.startswith('C'), 'Concept CUI expected')
             self.assertTrue(bsv.tui.startswith('T'), 'Type TUI expected')
-            self.assertEqual(bsv.vocab, 'SNOMEDCT_US', 'clinical terms vocab expected')
+            self.assertEqual(bsv.vocab, 'SNOMEDCT_US',
+                             'clinical terms vocab expected')
             self.assertIsNotNone(bsv.text)
             self.assertIsNotNone(bsv.pref)
 
     def test_umls_semantic_types(self):
-        bsv_list = ctakesclient.filesystem.list_bsv_semantics(PathResource.semantic_groups.value)
+        bsv_list = ctakesclient.filesystem.list_bsv_semantics(
+            PathResource.SEMANTIC_GROUPS.value)
 
         for bsv in bsv_list:
-            self.assertEqual(4, len(bsv.group_id), 'Group Abbreviations are 4 chars')
+            self.assertEqual(4, len(bsv.group_id),
+                             'Group Abbreviations are 4 chars')
             self.assertEqual(4, len(bsv.tui), 'TUI Abbreviations are 4 chars')
             self.assertTrue(bsv.tui.startswith('T'), 'Type TUI expected')
             self.assertIsNotNone(bsv.tui_label, 'TUI label should not be none')
 
         self.assertEqual(127, len(bsv_list), 'UMLS has 127 semantic types')
-        self.assertEqual(127, len(set([tui for tui in bsv_list])), 'UMLS has 127 unique TUI')
+        self.assertEqual(127, len(set(bsv_list)), 'UMLS has 127 unique TUI')
 
 
 if __name__ == '__main__':

--- a/test/test_negation.py
+++ b/test/test_negation.py
@@ -1,67 +1,79 @@
-from typing import List
-import logging
+"""Tests for basic negation"""
+
 import json
 import unittest
 import ctakesclient
 from ctakesclient.typesystem import Polarity
-from test.test_resources import PathResource, LoadResource
+from .test_resources import PathResource, LoadResource
+
 
 def covid_symptoms() -> dict:
-    return ctakesclient.filesystem.map_cui_pref(PathResource.covid_symptoms.value)
+    return ctakesclient.filesystem.map_cui_pref(
+        PathResource.COVID_SYMPTOMS.value)
+
 
 def note_negated_ros_review_of_symptoms() -> str:
-    return LoadResource.test_negation.value
+    return LoadResource.TEST_NEGATION.value
+
 
 def note_negated_denies() -> str:
     return 'Denies any fevers or chills, sore throat, anosmia, cough.'
 
-def note_positive_headache() ->str:
-    return 'Presents for a 5-day history of headache,sore throat, fever up to 100.5,cough,anosmia, dysgeusia.'
+
+def note_positive_headache() -> str:
+    return ('Presents for a 5-day history of headache,sore throat, fever '
+            'up to 100.5,cough,anosmia, dysgeusia.')
+
 
 def note_negation_api_example() -> str:
     """
     https://github.com/Machine-Learning-for-Medical-Language/cnlp_transformers#negation-api
     """
-    return 'The patient has a sore knee and headache but denies nausea and has no anosmia.'
+    return ('The patient has a sore knee and headache but denies nausea '
+            'and has no anosmia.')
+
 
 def pretty(result: dict) -> str:
     return json.dumps(result, indent=4)
+
 
 class TestNegationCtakesDefaultContext(unittest.TestCase):
     """
     https://cwiki.apache.org/confluence/display/CTAKES/cTAKES+3.0+-+NE+Contexts
     """
+
     def test_ctakes_covid_symptoms(self):
         ner = ctakesclient.client.extract(note_negated_ros_review_of_symptoms())
 
         symptoms_dict = covid_symptoms()
-        symptoms_fp = list()
+        symptoms_fp = []
 
         for match in ner.list_match(Polarity.pos):
             for concept in match.conceptAttributes:
-                as_json = json.dumps(match.as_json(), indent=4)
-                msg = f'########## \t Found false positive match: {as_json}'
-
-                if concept.cui in symptoms_dict.keys():
+                if concept.cui in symptoms_dict:
                     symptoms_fp.append(match)
 
-        self.assertEqual(list(), symptoms_fp,
-                         f'false positives found in purely NEGATED physician note review of systems {symptoms_fp}')
+        self.assertEqual([], symptoms_fp,
+                         ('false positives found in purely NEGATED physician '
+                          f'note review of systems {symptoms_fp}'))
 
-    @unittest.skip('https://github.com/comorbidity/ctakes-client-python/issues/2')
+    # pylint: disable-next=line-too-long
+    @unittest.skip('https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py/issues/8')
     def test_patient_denies(self):
         """
         Test everything in this example note is negated.
-        Unfortunately ctakes negation algorithm is not perfect. See linked issue #2.
+        Unfortunately ctakes negation algorithm is not perfect.
+        See linked issue above.
         """
         text = note_negated_denies()
-
-        false_positives = ctakesclient.client.extract(text).list_match_text(Polarity.pos)
-        self.assertEqual(list(), false_positives)
+        ner = ctakesclient.client.extract(text)
+        false_positives = ner.list_match_text(Polarity.pos)
+        self.assertEqual([], false_positives)
 
     def test_history_of_headache(self):
         text = note_positive_headache()
-        self.assertTrue('headache' in ctakesclient.client.extract(text).list_match_text())
+        ner = ctakesclient.client.extract(text)
+        self.assertIn('headache', ner.list_match_text())
 
 
 if __name__ == '__main__':

--- a/test/test_negation_transformer.py
+++ b/test/test_negation_transformer.py
@@ -1,7 +1,17 @@
-from typing import List
-from test.test_negation import *
+"""Tests for the machine learning negation API"""
 
-def list_false_positive_ss(physician_note:str) -> List[str]:
+import unittest
+from typing import List
+import ctakesclient
+from ctakesclient.typesystem import Polarity
+from .test_negation import (
+    note_negated_denies,
+    note_negated_ros_review_of_symptoms,
+    note_negation_api_example,
+)
+
+
+def list_false_positive_ss(physician_note: str) -> List[str]:
     """
     :param physician_note: note containing negated entries.
     :return: strings of symptoms that were actually marked *Polarity.pos*
@@ -9,21 +19,23 @@ def list_false_positive_ss(physician_note:str) -> List[str]:
     ner = ctakesclient.client.extract(physician_note)
     symptoms = ner.list_sign_symptom()
     spans = ner.list_spans(symptoms)
-    polarities_cnlp = ctakesclient.transformer.list_polarity(sentence=physician_note, spans=spans)
+    polarities_cnlp = ctakesclient.transformer.list_polarity(
+        sentence=physician_note, spans=spans)
 
-    fp = list()
+    fp = []
 
     for index in range(0, len(symptoms)):
         polarity = polarities_cnlp[index]
 
         if polarity != Polarity.neg:
             fp.append(symptoms[index].text)
-            # print(f'symptoms={symptoms}, polarities={polarities_cnlp}, text={note}')
+            # print(f'symptoms={symptoms}, polarities={polarities_cnlp}, '
+            #       f'text={note}')
     return fp
 
 
 def debug_helper(physician_note: str):
-    print('###############################################################################')
+    print('##################################################################')
     print(physician_note)
 
     ner = ctakesclient.client.extract(physician_note)
@@ -32,25 +44,29 @@ def debug_helper(physician_note: str):
     spans = ner.list_spans(matches)
 
     for match in matches:
-        print(f'{match.polarity.name}\t{match.span()}\t{match.text}\t\t{match.type.value}')
+        print(f'{match.polarity.name}\t{match.span()}\t{match.text}\t\t'
+              f'{match.type.value}')
 
-    polarities_cnlp = ctakesclient.transformer.list_polarity(physician_note, spans)
+    polarities_cnlp = ctakesclient.transformer.list_polarity(
+        physician_note, spans)
     polarities_ctakes = ner.list_polarity(spans)
 
-    print('###############################################################################')
+    print('##################################################################')
     print('cNLP=')
     print(polarities_cnlp)
 
-    print('###############################################################################')
+    print('##################################################################')
     print('cTAKES=')
     print(polarities_ctakes)
 
 
 class TestNegationTransformer(unittest.TestCase):
+    """Test case for the machine learning negation API"""
 
     def test_negation_api_example(self):
         """
-        Test negation using the example provided by the author of the server library (Tim Miller, PhD).
+        Test negation using the example provided by upstream.
+        (the author of the server library, Tim Miller, PhD)
         """
         self.assertPolarityCompatible(note_negation_api_example())
 
@@ -58,22 +74,25 @@ class TestNegationTransformer(unittest.TestCase):
         """
         Test simple 'patient denies' type statements.
         """
-        self.assertEqual(list(), list_false_positive_ss(note_negated_denies()))
+        self.assertEqual([], list_false_positive_ss(note_negated_denies()))
 
-    @unittest.skip('https://github.com/comorbidity/ctakes-client-python/issues/2')
+    # pylint: disable-next=line-too-long
+    @unittest.skip('https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py/issues/8')
     def test_negated_review_of_symptoms(self):
         """
         Test hard ROS section of a medical note.
         This is not yet 100% accurate and will take consider time to be perfect.
         Negation is not a solved problem in NLP community.
         """
-        self.assertEqual(list(), list_false_positive_ss(note_negated_ros_review_of_symptoms()))
+        self.assertEqual([], list_false_positive_ss(
+            note_negated_ros_review_of_symptoms()))
 
     def assertPolarityCompatible(self, text: str):
         ner = ctakesclient.client.extract(text)
         symptoms = ner.list_sign_symptom()
         polarities_ctakes = ner.list_polarity(symptoms)
-        polarities_cnlp = ctakesclient.transformer.list_polarity(text, ner.list_spans(symptoms))
+        polarities_cnlp = ctakesclient.transformer.list_polarity(
+            text, ner.list_spans(symptoms))
 
         self.assertEqual(polarities_ctakes, polarities_cnlp, text)
 

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -1,10 +1,14 @@
+"""Resource helpers for use in tests"""
+
 import os
 from enum import Enum
 import unittest
 from ctakesclient import filesystem
 
+
 def path(filename):
     return os.path.join(os.path.dirname(__file__), 'resources', filename)
+
 
 def load(filepath):
     if str(filepath).endswith('.json'):
@@ -19,23 +23,27 @@ def load(filepath):
 
 
 class PathResource(Enum):
-    covid_symptoms = path('covid_symptoms.bsv')
-    physician_note_text = path('test_physician_note.txt')
-    physician_note_json = path('test_physician_note.json')
-    test_negation = path('test_negation_hard.txt')
-    semantic_groups = path('SemGroups_2018.bsv')
+    COVID_SYMPTOMS = path('covid_symptoms.bsv')
+    PHYSICIAN_NOTE_TEXT = path('test_physician_note.txt')
+    PHYSICIAN_NOTE_JSON = path('test_physician_note.json')
+    TEST_NEGATION = path('test_negation_hard.txt')
+    SEMANTIC_GROUPS = path('SemGroups_2018.bsv')
+
 
 class LoadResource(Enum):
-    covid_symptoms = load(PathResource.covid_symptoms.value)
-    physician_note_text = load(PathResource.physician_note_text.value)
-    physician_note_json = load(PathResource.physician_note_json.value)
-    test_negation = load(PathResource.test_negation.value)
-    semantic_groups = load(PathResource.semantic_groups.value)
+    COVID_SYMPTOMS = load(PathResource.COVID_SYMPTOMS.value)
+    PHYSICIAN_NOTE_TEXT = load(PathResource.PHYSICIAN_NOTE_TEXT.value)
+    PHYSICIAN_NOTE_JSON = load(PathResource.PHYSICIAN_NOTE_JSON.value)
+    TEST_NEGATION = load(PathResource.TEST_NEGATION.value)
+    SEMANTIC_GROUPS = load(PathResource.SEMANTIC_GROUPS.value)
+
 
 class TestResourceValidity(unittest.TestCase):
+    """Test case for sanity checking resources"""
 
     def assertExists(self, resource_file):
-        self.assertTrue(os.path.exists(resource_file), f'resource did not exist: {resource_file}')
+        self.assertTrue(os.path.exists(resource_file),
+                        f'resource did not exist: {resource_file}')
 
     def test_resource_exists(self):
         for res in PathResource:

--- a/test/test_typesystem.py
+++ b/test/test_typesystem.py
@@ -1,56 +1,80 @@
+"""Tests for the typesystem module"""
+
 import unittest
-from typing import List
-import os
-import json
 
 from ctakesclient.typesystem import CtakesJSON, Polarity, UmlsConcept, MatchText
-from .test_resources import PathResource, LoadResource
+from .test_resources import LoadResource
+
 
 class TestCtakesJSON(unittest.TestCase):
+    """Test case for json parsing"""
 
     def test_physician_note(self):
-        reader = CtakesJSON(LoadResource.physician_note_json.value)
+        reader = CtakesJSON(LoadResource.PHYSICIAN_NOTE_JSON.value)
 
-        expected = {'headache', 'nausea', 'vomiting', 'chest pain', 'mental status'}
-        sign_symptom_neg = [m.text for m in reader.list_sign_symptom(Polarity.neg)]
+        expected = {
+            'headache', 'nausea', 'vomiting', 'chest pain', 'mental status'
+        }
+        sign_symptom_neg = [
+            m.text for m in reader.list_sign_symptom(Polarity.neg)
+        ]
         self.assertEqual(expected, set(sign_symptom_neg))
 
         expected = {'Diarrhea', 'cough'}
-        sign_symptom_pos = [m.text for m in reader.list_sign_symptom(Polarity.pos)]
+        sign_symptom_pos = [
+            m.text for m in reader.list_sign_symptom(Polarity.pos)
+        ]
         self.assertEqual(expected, set(sign_symptom_pos))
 
-        self.assertEqual(0, len(reader.list_disease_disorder()), 'no diseases expected')
-        self.assertEqual(0, len(reader.list_procedure()), 'no procedures expected')
-        self.assertEqual(0, len(reader.list_medication()), 'no medications expected')
+        self.assertEqual(0, len(reader.list_disease_disorder()),
+                         'no diseases expected')
+        self.assertEqual(0, len(reader.list_procedure()),
+                         'no procedures expected')
+        self.assertEqual(0, len(reader.list_medication()),
+                         'no medications expected')
 
     def test_umls_concept_medical_entries_exist(self):
-        expected = LoadResource.physician_note_json.value
+        expected = LoadResource.PHYSICIAN_NOTE_JSON.value
         actual = CtakesJSON(expected)
 
-        self.assertDictEqual(expected, actual.as_json(), 'ctakes json did not match before/after serialization')
+        self.assertDictEqual(
+            expected, actual.as_json(),
+            'ctakes json did not match before/after serialization')
 
-        self.assertGreaterEqual(len(actual.list_match()), 1, 'response should have at least one match')
-        self.assertGreaterEqual(len(actual.list_match_text()), 1, 'response should have at least one text match')
-        self.assertGreaterEqual(len(actual.list_concept()), 1, 'response should have at least one concept')
-        self.assertGreaterEqual(len(actual.list_concept_cui()), 1, 'response should have at least one concept CUI')
+        self.assertGreaterEqual(len(actual.list_match()), 1,
+                                'response should have at least one match')
+        self.assertGreaterEqual(len(actual.list_match_text()), 1,
+                                'response should have at least one text match')
+        self.assertGreaterEqual(len(actual.list_concept()), 1,
+                                'response should have at least one concept')
+        self.assertGreaterEqual(
+            len(actual.list_concept_cui()), 1,
+            'response should have at least one concept CUI')
 
     def test_sort_concept_list_match_chest(self):
         """
         Test fix for
         https://github.com/comorbidity/ctakes-client-python/issues/8
         """
-        snomed1 = UmlsConcept({'code': '51185008',  'cui': 'C0817096', 'codingScheme': 'SNOMEDCT_US', 'tui': 'T029'})
-        snomed2 = UmlsConcept({'code': '261179002', 'cui': 'C0817096', 'codingScheme': 'SNOMEDCT_US', 'tui': 'T029'})
-        loinc1 = UmlsConcept({'code': 'LP7138-3',  'cui': 'C1442171', 'codingScheme': 'LNC', 'tui': 'T029'}) # broader match entry
+        snomed1 = UmlsConcept({'code': '51185008',  'cui': 'C0817096',
+                               'codingScheme': 'SNOMEDCT_US', 'tui': 'T029'})
+        snomed2 = UmlsConcept({'code': '261179002', 'cui': 'C0817096',
+                               'codingScheme': 'SNOMEDCT_US', 'tui': 'T029'})
+        # broader match entry
+        loinc1 = UmlsConcept({'code': 'LP7138-3',  'cui': 'C1442171',
+                              'codingScheme': 'LNC', 'tui': 'T029'})
 
-        conceptAttributes1 = [snomed1, snomed2, loinc1]
-        conceptAttributes2 = [snomed2, snomed1, loinc1]
-        conceptAttributes3 = [loinc1, snomed1, snomed2]
-        conceptAttributes4 = [loinc1, snomed2, snomed1]
+        concept_attributes1 = [snomed1, snomed2, loinc1]
+        concept_attributes2 = [snomed2, snomed1, loinc1]
+        concept_attributes3 = [loinc1, snomed1, snomed2]
+        concept_attributes4 = [loinc1, snomed2, snomed1]
 
-        self.assertEqual(MatchText.sort_concepts(conceptAttributes1), MatchText.sort_concepts(conceptAttributes2))
-        self.assertEqual(MatchText.sort_concepts(conceptAttributes1), MatchText.sort_concepts(conceptAttributes3))
-        self.assertEqual(MatchText.sort_concepts(conceptAttributes1), MatchText.sort_concepts(conceptAttributes4))
+        self.assertEqual(MatchText.sort_concepts(concept_attributes1),
+                         MatchText.sort_concepts(concept_attributes2))
+        self.assertEqual(MatchText.sort_concepts(concept_attributes1),
+                         MatchText.sort_concepts(concept_attributes3))
+        self.assertEqual(MatchText.sort_concepts(concept_attributes1),
+                         MatchText.sort_concepts(concept_attributes4))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This should have no functional change (except for a couple places where we now assume utf8 encoding).

This style guide seems fine, but the 80-line limit is a little annoying.