### PR TITLE
Add pypi publish workflow, triggered by release creation

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,25 @@
+name: PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build
+      run: python -m build
+
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctakesclient"
-version = "1.0.0"
+version = "1.0.1"
 requires-python = ">= 3.10"
 dependencies = [
     "requests",


### PR DESCRIPTION
This only pushes to the test server for now. Once tested and good, we can switch it to the real one.

Part of https://github.com/comorbidity/ctakes-client-python/issues/1