### PR TITLE
ci: add pytest github actions CI file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+name: CI
+on: [push]
+
+jobs:
+  unittest:
+    name: unit tests
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r requirements.txt
+
+      - name: Test with pytest
+        run: |
+          # TODO: Expand our CI run to include the client/server tests too
+          # https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py/issues/10
+          python -m pytest test/test_filesystem.py test/test_resources.py test/test_typesystem.py

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -4,7 +4,7 @@ import unittest
 from ctakesclient import filesystem
 
 def path(filename):
-    return os.path.join(os.getcwd(), f'resources/{filename}')
+    return os.path.join(os.path.dirname(__file__), 'resources', filename)
 
 def load(filepath):
     if str(filepath).endswith('.json'):

--- a/test/test_typesystem.py
+++ b/test/test_typesystem.py
@@ -4,7 +4,7 @@ import os
 import json
 
 from ctakesclient.typesystem import CtakesJSON, Polarity, UmlsConcept, MatchText
-from test_resources import PathResource, LoadResource
+from .test_resources import PathResource, LoadResource
 
 class TestCtakesJSON(unittest.TestCase):
 


### PR DESCRIPTION
Currently, we only run the local tests. See https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py/issues/10 as the tracker for adding more.