### PR TITLE
Drop minimum python to 3.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest
-          pip install -r requirements.txt
+          pip install .[tests]
 
       - name: Test with pytest
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ctakesclient"
-version = "1.0.1"
-requires-python = ">= 3.10"
+version = "1.0.3"
+requires-python = ">= 3.7"
 dependencies = [
     "requests",
 ]
@@ -29,3 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["ctakesclient"]
+
+[project.optional-dependencies]
+tests = [
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-requests


### PR DESCRIPTION
It's the oldest version that hasn't hit EOL yet.