### PR TITLE
build: move version into code and switch to flit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,12 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest
-          # Once we drop support for py3.6, we can use standard pip install again.
-          # The issue is that we need setuptools 61.0 for pyproject.toml support,
-          # but setuptools 59.7 dropped support for py3.6.
-          # But for now, manually install all requirements:
-          pip install requests
-          # pip install .[tests]
+          pip install .[tests]
 
       - name: Test with pytest
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-graft docs
-graft scripts
-graft test/resources

--- a/ctakesclient/__init__.py
+++ b/ctakesclient/__init__.py
@@ -1,5 +1,7 @@
 """Public API"""
 
+__version__ = '1.1.0'
+
 from . import typesystem
 from . import filesystem
 from . import client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [project]
 name = "ctakesclient"
-version = "1.0.4"
 # We'll want to officially support 3.6 until we no longer care about CentOS 7
 requires-python = ">= 3.6"
 dependencies = [
@@ -20,16 +19,22 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+dynamic = ["version"]
 
 [project.urls]
 "Homepage" = "https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py"
 
 [build-system]
-requires = ["setuptools >= 61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["flit_core >=3.4,<4"]
+build-backend = "flit_core.buildapi"
 
-[tool.setuptools]
-packages = ["ctakesclient"]
+[tool.flit.sdist]
+include = [
+    "docs/",
+    "scripts/",
+    "test/",
+    "LICENSE",
+]
 
 [project.optional-dependencies]
 docs = [


### PR DESCRIPTION
- Mark version dynamic and move it from pyproject into ctakesclient.__version__ (a quasi-standard location)
- Switch from setuptools to flit because (a) it made the above trivial and (b) it still works fine with pyproject on py3.6, unlike setuptools and we can simplify our CI again