### PR TITLE
client: clean up handling of unicode characters

### DIFF
--- a/ctakesclient/client.py
+++ b/ctakesclient/client.py
@@ -26,21 +26,97 @@ def get_url_ctakes_rest() -> str:
 
 def post(sentence: str, url: str = None) -> dict:
     """
+    Sends clinical text to cTAKES for analysis and returns the raw server response
+
+    You likely want the higher-level `extract` method instead of this one.
+    For one, it will return a nice `CtakesJSON` object instead of raw json.
+    For another, the raw cTAKES response has some oddities, like utf16-based span indexes,
+    which `extract` fixes for you.
+
     :param sentence: clinical text to send to cTAKES
     :param url: cTAKES REST server fully qualified path
-    :return:
+    :return: Parsed json response from cTAKES
     """
     url = url or get_url_ctakes_rest()
     logging.debug(url)
     # TODO: consider exposing a pass-through timeout parameter
-    return requests.post(url, data=sentence).json()  # pylint: disable=missing-timeout
+    response = requests.post(  # pylint: disable=missing-timeout
+        url,
+        data=sentence.encode('utf8'),
+        headers={
+            'Content-Type': 'text/plain; charset=UTF-8',
+        }
+    )
+    response.raise_for_status()
+    return response.json()
 
 
 def extract(sentence: str, url: str = None) -> CtakesJSON:
     """
+    Send clinical text to cTAKES for analysis and packages the response up for you
+
     :param sentence: clinical text to send to cTAKES
     :param url: cTAKES REST server fully qualified path
     :return: CtakesJSON wrapper
     """
     url = url or get_url_ctakes_rest()
-    return CtakesJSON(post(sentence, url))
+    ner = CtakesJSON(post(sentence, url))
+    _adjust_character_indexes(sentence, ner)  # Fix Java character indexes into Python ones
+    return ner
+
+
+###############################################################################
+#
+# Helpers
+#
+###############################################################################
+
+def _utf16le_to_unicode_index(utf16: bytes, code_point_index: int) -> int:
+    """
+    Adjust one utf-16-le-code-point-index into a character-index for the given string
+    """
+    bytes_index = code_point_index * 2  # all code points are 2-bytes
+    prefix = utf16[0:bytes_index].decode('utf-16-le')
+    return len(prefix)  # and the length of that is the character index into the original unicode string
+
+
+def _adjust_character_indexes(original: str, ner: CtakesJSON) -> None:
+    """
+    Adjust any span begin/end values from a cTAKES utf16-code-point-index into a character-index
+
+    cTAKES responses give very Java-centric begin/end values as the code-point index into
+    a utf16 encoding of the given string. But as a Python module, we should instead expose
+    character indexes in case anyone wants to go back to the original string.
+
+    So this method fixes all found span indexes into a more Pythonic character index.
+    This is important to do because `ctakesclient.transformer` does expect the given
+    spans to be character indexes. So if we don't do this, we'll get odd results from it.
+
+    In practice, this is often the same position value -- it only really changes for unicode
+    scalar values higher than U+FFFF (i.e. those that can't be encoded in just two bytes).
+    """
+    # Try to early exit by seeing if any character in the source is actually above U+FFFF (usually not)
+    for c in original:
+        if ord(c) > 0xffff:
+            break
+    else:
+        return  # nothing to do, utf16-code-points happen to be the same as characters, so early exit
+
+    # Ah well, looks like we'll have to actually translate the indexes
+
+    utf16 = original.encode('utf-16-le')  # use low-endian encoding to avoid a byte-order-mark messing up our counts
+    matches = ner.list_match()
+    cache = {}  # use a cache, just because a lot of indexes do get re-used between concepts
+    for match in matches:
+        # We could try to be clever here and use the length of match.text to calculate the correct end position,
+        # but I have some concerns that match.text is maybe unicode-normalized and doesn't represent the text in
+        # the original source text byte-for-byte. So just to be super-safe, convert both begin and end by looking
+        # at the source text, since that's where they were defined from.
+        for index_attr in ['begin', 'end']:
+            index = getattr(match, index_attr)
+            if index in cache:
+                setattr(match, index_attr, cache[index])
+            else:
+                value = _utf16le_to_unicode_index(utf16, index)
+                setattr(match, index_attr, value)
+                cache[index] = value

--- a/ctakesclient/transformer.py
+++ b/ctakesclient/transformer.py
@@ -34,7 +34,9 @@ def list_polarity(sentence: str, spans: list, url: str = None) -> List[Polarity]
     doc = {'doc_text': sentence, 'entities': spans}
 
     # TODO: consider exposing a pass-through timeout parameter
-    response = requests.post(url=url, json=doc).json()  # pylint: disable=missing-timeout
+    response = requests.post(url=url, json=doc)  # pylint: disable=missing-timeout
+    response.raise_for_status()
+    response = response.json()
     polarities = []
 
     for status in response['statuses']:

--- a/test/integration/test_client_ctakes_rest_server.py
+++ b/test/integration/test_client_ctakes_rest_server.py
@@ -26,10 +26,18 @@ class TestClientCtakesRestServer(unittest.TestCase):
         self.assertDictEqual(actual1, actual2,
                              'calling service twice produces same results')
 
+    def test_unicode(self):
+        """Ensure that we handle utf8/unicode correctly"""
+        # First, make sure we don't blow up just by sending it
+        ner = ctakesclient.client.extract('patient feels 🤒 with fever')
+
+        # Then confirm that our spans are correct (0-based and character-based)
+        self.assertEqual(1, len(ner.list_sign_symptom()))
+        symptom = ner.list_sign_symptom()[0]
+        self.assertEqual('fever', symptom.text)
+        self.assertEqual(21, symptom.begin)
+        self.assertEqual(26, symptom.end)
+
 
 if __name__ == '__main__':
     unittest.main()
-
-
-
-


### PR DESCRIPTION
- Send utf8, not latin1 to cTAKES server
- Properly interpret begin/end positions from cTAKES as utf-16 code point indexes
- Also, raise an exception if the server response is 4xx or 5xx.


Fixes: #16