### PR TITLE
text2fhir: add new submodule for converting NLP to FHIR

### DIFF
--- a/ctakesclient/__init__.py
+++ b/ctakesclient/__init__.py
@@ -1,8 +1,9 @@
 """Public API"""
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
-from . import typesystem
-from . import filesystem
 from . import client
+from . import filesystem
+from . import text2fhir
 from . import transformer
+from . import typesystem

--- a/ctakesclient/text2fhir.py
+++ b/ctakesclient/text2fhir.py
@@ -1,0 +1,431 @@
+"""Transforms cTAKES output into FHIR resources"""
+
+import uuid
+from enum import Enum
+from typing import List, Optional
+
+from fhirclient.models.codeableconcept import CodeableConcept
+from fhirclient.models.coding import Coding
+from fhirclient.models.condition import Condition
+from fhirclient.models.extension import Extension
+from fhirclient.models.fhirreference import FHIRReference
+from fhirclient.models.observation import Observation
+from fhirclient.models.medicationstatement import MedicationStatement
+from fhirclient.models.procedure import Procedure
+from fhirclient.models.resource import Resource
+
+import ctakesclient
+from ctakesclient.typesystem import MatchText, Polarity, Span
+
+
+###############################################################################
+# URLs to qualify Extensions:
+#   FHIR DerivationReference
+#   SMART-on-FHIR StructureDefinition
+###############################################################################
+FHIR_DERIVATION_REF_URL = 'http://hl7.org/fhir/StructureDefinition/derivation-reference'
+NLP_SOURCE_URL = 'http://fhir-registry.smarthealthit.org/StructureDefinition/nlp-source'
+NLP_POLARITY_URL = 'http://fhir-registry.smarthealthit.org/StructureDefinition/nlp-polarity'
+
+
+class Vocab(Enum):
+    """
+    https://build.fhir.org/terminologies-systems.html
+    """
+    SNOMEDCT_US = 'http://snomed.info/sct'
+    RXNORM = 'http://www.nlm.nih.gov/research/umls/rxnorm'
+    LOINC = 'http://loinc.org'
+    LNC = 'http://loinc.org'
+    CPT = 'http://www.ama-assn.org/go/cpt'
+    MEDRT = 'http://va.gov/terminology/medrt'
+    NDFRT = 'http://hl7.org/fhir/ndfrt'
+    NDC = 'http://hl7.org/fhir/sid/ndc'
+    CVX = 'http://hl7.org/fhir/sid/cvx'
+    ICD9 = 'ICD-9'
+    ICD10 = 'ICD-10'
+    UMLS = 'http://terminology.hl7.org/CodeSystem/umls'
+
+
+def _vocab_url(umls_sab: str) -> Optional[str]:
+    """
+    Returns the URL for the given UMLS vocabulary, or None if it's custom or not recognized
+
+    See https://www.nlm.nih.gov/research/umls/sourcereleasedocs/index.html
+
+    :param umls_sab: UMLS SAB = "Source Abbreviation"
+    :return: URL of UMLS vocab
+    """
+    if not hasattr(Vocab, umls_sab):
+        return None
+    return str(Vocab[umls_sab].value)
+
+
+###############################################################################
+# Common extension helper methods
+#
+###############################################################################
+
+def _value_string(url: str, value: str) -> Extension:
+    """
+    :param url: either URL or simple "key"
+    :param value: valueString to associate with URL
+    :return: Extension with simple url:valueString
+    """
+    return Extension({'url': url, 'valueString': value})
+
+
+def _value_integer(url: str, value: str) -> Extension:
+    """
+    :param url: either URL or simple "key"
+    :param value: valueInteger to associate with URL
+    :return: Extension with simple url:valueInteger
+    """
+    return Extension({'url': url, 'valueInteger': value})
+
+
+def _value_boolean(url: str, value: bool) -> Extension:
+    """
+    :param url: either URL or simple "key"
+    :param value: valueString to associate with URL
+    :return: Extension with simple url:valueBoolean
+    """
+    return Extension({'url': url, 'valueBoolean': value})
+
+
+def _value_reference(value: FHIRReference) -> Extension:
+    """
+    :param value: valueString to associate with URL
+    :return: Extension with reference:FHIRReference like 'Patient/123456789'
+    """
+    return Extension({'url': 'reference', 'valueReference': value.as_json()})
+
+
+def _value_list(url: str, values: List[Extension]) -> Extension:
+    """
+    :param url: either URL or simple "key"
+    :param values: nested list of extensions
+    :return: Extension with nested content extension:List
+    """
+    return Extension({'url': url, 'extension': [v.as_json() for v in values]})
+
+
+###############################################################################
+# Standard FHIR References are ResourceType/id
+###############################################################################
+
+def _random_id() -> str:
+    """
+    Provides a random id for newly created resources
+
+    Users may override these, but nice to give them something valid if they don't care.
+    """
+    return str(uuid.uuid4())
+
+
+def _ref_resource(resource_type: str, resource_id: str) -> FHIRReference:
+    """
+    Reference the FHIR proper way
+    :param resource_type: Name of resource, like "Patient"
+    :param resource_id: ID for resource (isa REF can be UUID)
+    :return: FHIRReference as Resource/$id
+    """
+    if not resource_id:
+        raise ValueError('Missing resource ID')
+    return FHIRReference({'reference': f'{resource_type}/{resource_id}'})
+
+
+def _ref_subject(subject_id: str) -> FHIRReference:
+    """
+    Patient Reference the FHIR proper way
+    :param subject_id: ID for patient (isa REF can be UUID)
+    :return: FHIRReference as Patient/$id
+    """
+    return _ref_resource('Patient', subject_id)
+
+
+def _ref_encounter(encounter_id: str) -> FHIRReference:
+    """
+    Encounter Reference the FHIR proper way
+    :param encounter_id: ID for encounter (isa REF can be UUID)
+    :return: FHIRReference as Encounter/$id
+    """
+    return _ref_resource('Encounter', encounter_id)
+
+
+def _ref_document(docref_id: str) -> FHIRReference:
+    """
+    Encounter Reference the FHIR proper way
+    :param docref_id: ID for encounter (isa REF can be UUID)
+    :return: FHIRReference as Encounter/$id
+    """
+    return _ref_resource('DocumentReference', docref_id)
+
+
+###############################################################################
+# modifierExtension
+#   "nlp-source" is Required
+#   "nlp-polarity" is Optional
+#
+###############################################################################
+
+def _nlp_modifier(source=None, polarity=None) -> List[Extension]:
+    """
+    :param source: default = "ctakesclient" with version tag.
+    :param polarity: pos= concept is true, neg=concept is negated ("patient denies cough")
+    :return: FHIR resource.modifierExtension
+    """
+    if source is None:
+        source = _nlp_source()
+
+    if polarity is None:
+        return [source]
+    else:
+        return [source, _nlp_polarity(polarity)]
+
+
+def _nlp_source(algorithm=None, version=None) -> Extension:
+    """
+    :param algorithm: optional, default = "ctakesclient".
+    :param version: optional, default = "ctakesclient" version.
+    """
+    values = [_nlp_algorithm(algorithm), _nlp_version(version)]
+    return _value_list(NLP_SOURCE_URL, values)
+
+
+def _nlp_algorithm(algorithm=None) -> Extension:
+    """
+    :param algorithm: optional, default = "ctakesclient".
+    """
+    if not algorithm:
+        algorithm = ctakesclient.__package__
+
+    return _value_string('algorithm', algorithm)
+
+
+def _nlp_version(version=None) -> Extension:
+    """
+    :param version: optional, default = "ctakesclient" version.
+    """
+    if version is None:
+        release = ctakesclient.__version__
+        version = f'https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py/releases/tag/v{release}'
+
+    return _value_string('version', version)
+
+
+def _nlp_polarity(polarity: Polarity) -> Extension:
+    """
+    :param polarity: pos= concept is true, neg=concept is negated ("patient denies cough")
+    """
+    positive = polarity == Polarity.pos
+    return _value_boolean(NLP_POLARITY_URL, positive)
+
+
+###############################################################################
+#  DerivationReference
+#
+#   "reference" is Required
+#   "offset" is Optional
+#   "length" is Optional
+#
+###############################################################################
+
+def _nlp_derivation_span(docref_id, span: Span) -> Extension:
+    return _nlp_derivation(docref_id=docref_id, offset=span.begin, length=(span.end - span.begin))
+
+
+def _nlp_derivation(docref_id, offset=None, length=None) -> Extension:
+    """
+    README: http://build.fhir.org/extension-derivation-reference.html
+
+    :param docref_id: ID for the DocumentReference from which NLP resource was derived.
+    :param offset: optional character *offset in document* (integer!)
+    :param length: optional character *length from offset* of the matching text span.
+    :return: Extension for DerivationReference defining which document and text position was derived using NLP
+    """
+    values = [_value_reference(_ref_document(docref_id))]
+
+    if offset:
+        values.append(_value_integer('offset', offset))
+
+    if length:
+        values.append(_value_integer('length', length))
+
+    values = [v.as_json() for v in values]
+
+    return Extension({'url': FHIR_DERIVATION_REF_URL, 'extension': values})
+
+
+def _nlp_extensions(fhir_resource: Resource, docref_id: str, nlp_match: MatchText, source=None) -> None:
+    """
+    apply "extensions" and "modiferExtension" to provided $fhir_resource
+
+    :param fhir_resource: passed by reference
+    :param docref_id: ID for DocumentReference (isa REF can be UUID)
+    :param nlp_match: response from cTAKES or other NLP Client
+    :param source: NLP Version information, if none is provided use version of ctakesclient.
+    """
+    fhir_resource.modifierExtension = _nlp_modifier(source, nlp_match.polarity)
+    fhir_resource.extension = [_nlp_derivation_span(docref_id, nlp_match.span())]
+
+
+###############################################################################
+#
+# Individual NLP conversion functions for a single MatchText
+#
+###############################################################################
+
+def nlp_concept(match: MatchText) -> CodeableConcept:
+    """
+    NLP match --> FHIR CodeableConcept
+
+    :param match: everything needed to make CodeableConcept
+    :return: FHIR CodeableConcept with both UMLS CUI and source vocab CODE
+    """
+    coded = []
+    for concept in match.conceptAttributes:
+        coded.append(Coding({'system': _vocab_url(concept.codingScheme), 'code': concept.code}))
+        coded.append(Coding({'system': Vocab.UMLS.value, 'code': concept.cui}))
+
+    return CodeableConcept({'text': match.text, 'coding': [c.as_json() for c in coded]})
+
+
+def nlp_condition(
+        subject_id: str,
+        encounter_id: str,
+        docref_id: str,
+        nlp_match: MatchText,
+        source: Extension = None,
+) -> Condition:
+    """
+    FHIR Condition from an NLP match (e.g. a disease disorder)
+
+    Use this method to get FHIR resource for a note that is for a ** specific encounter **.
+    Be advised that a single note can reference past medical history.
+
+    :param subject_id: ID for patient (isa REF can be UUID)
+    :param encounter_id: ID for visit (isa REF can be UUID)
+    :param docref_id: ID for DocumentReference (isa REF can be UUID)
+    :param nlp_match: response from cTAKES or other NLP Client
+    :param source: NLP Version information, if none is provided use version of ctakesclient.
+    :return: FHIR Condition (note it will have a random id)
+    """
+    condition = Condition()
+
+    # id linkage
+    condition.id = _random_id()
+    condition.subject = _ref_subject(subject_id)
+    condition.encounter = _ref_encounter(encounter_id)
+
+    # status is unconfirmed - NLP is not perfect.
+    status = Coding({'system': 'http://terminology.hl7.org/CodeSystem/condition-ver-status', 'code': 'unconfirmed'})
+    condition.verificationStatus = CodeableConcept({'text': 'Unconfirmed', 'coding': [status.as_json()]})
+
+    # NLP
+    _nlp_extensions(condition, docref_id, nlp_match, source)
+    condition.code = nlp_concept(nlp_match)
+
+    return condition
+
+
+def nlp_observation(
+        subject_id: str,
+        encounter_id: str,
+        docref_id: str,
+        nlp_match: MatchText,
+        source: Extension = None,
+) -> Observation:
+    """
+    FHIR Observation from an NLP match (e.g. a sign symptom)
+
+    Use this method to get FHIR resource for a note that is for a ** specific encounter **.
+    Be advised that a single note can reference past medical history.
+
+    :param subject_id: ID for patient (isa REF can be UUID)
+    :param encounter_id: ID for visit (isa REF can be UUID)
+    :param nlp_match: response from cTAKES or other NLP Client
+    :param source: NLP Version information, if none is provided use version of ctakesclient.
+    :return: FHIR Observation (note it will have a random id)
+    """
+    observation = Observation()
+
+    # id linkage
+    observation.id = _random_id()
+    observation.subject = _ref_subject(subject_id)
+    observation.encounter = _ref_encounter(encounter_id)
+    observation.status = 'preliminary'
+
+    # NLP
+    _nlp_extensions(observation, docref_id, nlp_match, source)
+    observation.code = nlp_concept(nlp_match)
+
+    return observation
+
+
+def nlp_medication(
+        subject_id: str,
+        encounter_id: str,
+        docref_id: str,
+        nlp_match: MatchText,
+        source: Extension = None,
+) -> MedicationStatement:
+    """
+    FHIR MedicationStatement from an NLP match
+
+    Use this method to get FHIR resource for a note that is for a ** specific encounter **.
+    Be advised that a single note can reference past medical history.
+
+    :param subject_id: ID for patient (isa REF can be UUID)
+    :param encounter_id: ID for encounter (isa REF can be UUID)
+    :param nlp_match: response from cTAKES or other NLP Client
+    :param source: NLP Version information, if none is provided use version of ctakesclient.
+    :return: FHIR MedicationStatement (note it will have a random id)
+    """
+    medication = MedicationStatement()
+
+    # id linkage
+    medication.id = _random_id()
+    medication.subject = _ref_subject(subject_id)
+    medication.context = _ref_encounter(encounter_id)
+    medication.status = 'unknown'
+
+    # NLP
+    _nlp_extensions(medication, docref_id, nlp_match, source)
+    medication.medicationCodeableConcept = nlp_concept(nlp_match)
+
+    return medication
+
+
+def nlp_procedure(
+        subject_id: str,
+        encounter_id: str,
+        docref_id: str,
+        nlp_match: MatchText,
+        source: Extension = None,
+) -> Procedure:
+    """
+    FHIR Procedure from an NLP match
+
+    Use this method to get FHIR resource for a note that is for a ** specific encounter **.
+    Be advised that a single note can reference past medical history.
+
+    :param subject_id: ID for Patient (isa REF can be UUID)
+    :param encounter_id: ID for visit (isa REF can be UUID)
+    :param docref_id: ID for DocumentReference (isa REF can be UUID)
+    :param nlp_match: response from cTAKES or other NLP Client
+    :param source: NLP Version information, if none is provided use version of ctakesclient.
+    :return: FHIR Procedure (note it will have a random id)
+    """
+    procedure = Procedure()
+
+    # id linkage
+    procedure.id = _random_id()
+    procedure.subject = _ref_subject(subject_id)
+    procedure.encounter = _ref_encounter(encounter_id)
+    procedure.status = 'unknown'
+
+    # NLP
+    _nlp_extensions(procedure, docref_id, nlp_match, source)
+    procedure.code = nlp_concept(nlp_match)
+
+    return procedure

--- a/ctakesclient/typesystem.py
+++ b/ctakesclient/typesystem.py
@@ -166,7 +166,7 @@ class MatchText:
         self.conceptAttributes = []
 
         # sort list of concepts ensuring same ordering
-        unsorted = list(UmlsConcept(c) for c in source.get('conceptAttributes'))
+        unsorted = list(UmlsConcept(c) for c in source.get('conceptAttributes', []))
 
         for c in MatchText.sort_concepts(unsorted):
             self.conceptAttributes.append(c)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "ctakesclient"
 # We'll want to officially support 3.6 until we no longer care about CentOS 7
 requires-python = ">= 3.6"
 dependencies = [
+    "fhirclient >= 4.1",
     "requests",
 ]
 authors = [

--- a/test/resources/synthentic.txt
+++ b/test/resources/synthentic.txt
@@ -1,0 +1,168 @@
+
+2021-09-18
+
+# Chief Complaint
+No complaints.
+
+# History of Present Illness
+Alan320
+ is a 10 year-old non-hispanic white male. Patient has a history of acute viral pharyngitis (disorder), sprain of wrist, suspected covid-19.
+
+# Social History
+ Patient has never smoked.
+
+
+Patient comes from a middle socioeconomic background.
+
+Patient currently has Blue Cross Blue Shield.
+
+# Allergies
+No Known Allergies.
+
+# Medications
+acetaminophen 160 mg chewable tablet
+
+# Assessment and Plan
+
+
+## Plan
+Patient was given the following immunizations: influenza, seasonal, injectable, preservative free. 
+The following procedures were conducted:
+- medication reconciliation (procedure)
+
+
+
+2020-09-12
+
+# Chief Complaint
+No complaints.
+
+# History of Present Illness
+Alan320
+ is a 9 year-old non-hispanic white male. Patient has a history of acute viral pharyngitis (disorder), sprain of wrist, suspected covid-19.
+
+# Social History
+ Patient has never smoked.
+
+
+Patient comes from a middle socioeconomic background.
+
+Patient currently has Aetna.
+
+# Allergies
+No Known Allergies.
+
+# Medications
+acetaminophen 160 mg chewable tablet
+
+# Assessment and Plan
+
+
+## Plan
+Patient was given the following immunizations: influenza, seasonal, injectable, preservative free. 
+The following procedures were conducted:
+- medication reconciliation (procedure)
+
+
+
+2020-03-18
+
+# Chief Complaint
+No complaints.
+
+# History of Present Illness
+Alan320
+ is a 8 year-old non-hispanic white male. Patient has a history of acute viral pharyngitis (disorder), sprain of wrist.
+
+# Social History
+ Patient has never smoked.
+
+
+Patient comes from a middle socioeconomic background.
+
+Patient currently has Aetna.
+
+# Allergies
+No Known Allergies.
+
+# Medications
+acetaminophen 160 mg chewable tablet
+
+# Assessment and Plan
+Patient is presenting with sputum finding (finding), fatigue (finding), fever (finding), loss of taste (finding), suspected covid-19. 
+
+## Plan
+
+The following procedures were conducted:
+- face mask (physical object)
+The patient was placed on a careplan:
+- infectious disease care plan (record artifact)
+
+
+
+2020-03-05
+
+# Chief Complaint
+No complaints.
+
+# History of Present Illness
+Alan320
+ is a 8 year-old non-hispanic white male. Patient has a history of acute viral pharyngitis (disorder).
+
+# Social History
+ Patient has never smoked.
+
+
+Patient comes from a middle socioeconomic background.
+
+Patient currently has Aetna.
+
+# Allergies
+No Known Allergies.
+
+# Medications
+No Active Medications.
+
+# Assessment and Plan
+Patient is presenting with sprain of wrist. 
+
+## Plan
+
+The patient was prescribed the following medications:
+- acetaminophen 160 mg chewable tablet
+The patient was placed on a careplan:
+- physical therapy procedure
+
+
+
+2019-10-28
+
+# Chief Complaint
+No complaints.
+
+# History of Present Illness
+Alan320
+ is a 8 year-old non-hispanic white male.
+
+# Social History
+ Patient has never smoked.
+
+
+Patient comes from a middle socioeconomic background.
+
+Patient currently has Aetna.
+
+# Allergies
+No Known Allergies.
+
+# Medications
+No Active Medications.
+
+# Assessment and Plan
+Patient is presenting with acute viral pharyngitis (disorder). 
+
+## Plan
+
+
+
+

--- a/test/resources/synthetic.json
+++ b/test/resources/synthetic.json
@@ -1,0 +1,2054 @@
+{
+    "MedicationMention": [
+        {
+            "begin": 442,
+            "end": 457,
+            "text": "chewable tablet",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "91058",
+                    "cui": "C0304290",
+                    "codingScheme": "RXNORM",
+                    "tui": "T122"
+                },
+                {
+                    "code": "66076007",
+                    "cui": "C0304290",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T122"
+                }
+            ],
+            "type": "MedicationMention"
+        },
+        {
+            "begin": 1098,
+            "end": 1113,
+            "text": "chewable tablet",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "91058",
+                    "cui": "C0304290",
+                    "codingScheme": "RXNORM",
+                    "tui": "T122"
+                },
+                {
+                    "code": "66076007",
+                    "cui": "C0304290",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T122"
+                }
+            ],
+            "type": "MedicationMention"
+        },
+        {
+            "begin": 1734,
+            "end": 1749,
+            "text": "chewable tablet",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "66076007",
+                    "cui": "C0304290",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T122"
+                },
+                {
+                    "code": "91058",
+                    "cui": "C0304290",
+                    "codingScheme": "RXNORM",
+                    "tui": "T122"
+                }
+            ],
+            "type": "MedicationMention"
+        },
+        {
+            "begin": 2601,
+            "end": 2614,
+            "text": "acetaminophen",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "387517004",
+                    "cui": "C0000970",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T121"
+                },
+                {
+                    "code": "90332006",
+                    "cui": "C0000970",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T121"
+                },
+                {
+                    "code": "161",
+                    "cui": "C0000970",
+                    "codingScheme": "RXNORM",
+                    "tui": "T121"
+                }
+            ],
+            "type": "MedicationMention"
+        },
+        {
+            "begin": 2622,
+            "end": 2637,
+            "text": "chewable tablet",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "66076007",
+                    "cui": "C0304290",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T122"
+                },
+                {
+                    "code": "91058",
+                    "cui": "C0304290",
+                    "codingScheme": "RXNORM",
+                    "tui": "T122"
+                }
+            ],
+            "type": "MedicationMention"
+        }
+    ],
+    "AnatomicalSiteMention": [
+        {
+            "begin": 198,
+            "end": 203,
+            "text": "wrist",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "8205005",
+                    "cui": "C0043262",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T029"
+                }
+            ],
+            "type": "AnatomicalSiteMention"
+        },
+        {
+            "begin": 871,
+            "end": 876,
+            "text": "wrist",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "8205005",
+                    "cui": "C0043262",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T029"
+                }
+            ],
+            "type": "AnatomicalSiteMention"
+        },
+        {
+            "begin": 1527,
+            "end": 1532,
+            "text": "wrist",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "8205005",
+                    "cui": "C0043262",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T029"
+                }
+            ],
+            "type": "AnatomicalSiteMention"
+        },
+        {
+            "begin": 1961,
+            "end": 1965,
+            "text": "face",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "89545001",
+                    "cui": "C0015450",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T029"
+                }
+            ],
+            "type": "AnatomicalSiteMention"
+        },
+        {
+            "begin": 2527,
+            "end": 2532,
+            "text": "wrist",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "8205005",
+                    "cui": "C0043262",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T029"
+                }
+            ],
+            "type": "AnatomicalSiteMention"
+        }
+    ],
+    "DiseaseDisorderMention": [
+        {
+            "begin": 152,
+            "end": 175,
+            "text": "acute viral pharyngitis",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "195662009",
+                    "cui": "C0396000",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 177,
+            "end": 185,
+            "text": "disorder",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "64572001",
+                    "cui": "C0012634",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 188,
+            "end": 203,
+            "text": "sprain of wrist",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "70704007",
+                    "cui": "C0160063",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T037"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 215,
+            "end": 223,
+            "text": "covid-19",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "840539006",
+                    "cui": "C5203670",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 538,
+            "end": 547,
+            "text": "influenza",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "6142004",
+                    "cui": "C0021400",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 825,
+            "end": 848,
+            "text": "acute viral pharyngitis",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "195662009",
+                    "cui": "C0396000",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 850,
+            "end": 858,
+            "text": "disorder",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "64572001",
+                    "cui": "C0012634",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 861,
+            "end": 876,
+            "text": "sprain of wrist",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "70704007",
+                    "cui": "C0160063",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T037"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 888,
+            "end": 896,
+            "text": "covid-19",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "840539006",
+                    "cui": "C5203670",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 1194,
+            "end": 1203,
+            "text": "influenza",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "6142004",
+                    "cui": "C0021400",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 1481,
+            "end": 1504,
+            "text": "acute viral pharyngitis",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "195662009",
+                    "cui": "C0396000",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 1506,
+            "end": 1514,
+            "text": "disorder",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "64572001",
+                    "cui": "C0012634",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 1517,
+            "end": 1532,
+            "text": "sprain of wrist",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "70704007",
+                    "cui": "C0160063",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T037"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 1897,
+            "end": 1905,
+            "text": "covid-19",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "840539006",
+                    "cui": "C5203670",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 2029,
+            "end": 2047,
+            "text": "infectious disease",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "40733004",
+                    "cui": "C0009450",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                },
+                {
+                    "code": "189822004",
+                    "cui": "C0009450",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                },
+                {
+                    "code": "191415002",
+                    "cui": "C0009450",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 2229,
+            "end": 2252,
+            "text": "acute viral pharyngitis",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "195662009",
+                    "cui": "C0396000",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 2254,
+            "end": 2262,
+            "text": "disorder",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "64572001",
+                    "cui": "C0012634",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 2517,
+            "end": 2532,
+            "text": "sprain of wrist",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "70704007",
+                    "cui": "C0160063",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T037"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 3085,
+            "end": 3108,
+            "text": "acute viral pharyngitis",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "195662009",
+                    "cui": "C0396000",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        },
+        {
+            "begin": 3110,
+            "end": 3118,
+            "text": "disorder",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "64572001",
+                    "cui": "C0012634",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T047"
+                }
+            ],
+            "type": "DiseaseDisorderMention"
+        }
+    ],
+    "SignSymptomMention": [
+        {
+            "begin": 21,
+            "end": 30,
+            "text": "Complaint",
+            "polarity": -1,
+            "conceptAttributes": [
+                {
+                    "code": "409586006",
+                    "cui": "C0277786",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                },
+                {
+                    "code": "33962009",
+                    "cui": "C0277786",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 49,
+            "end": 56,
+            "text": "History",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "392521001",
+                    "cui": "C0262926",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 60,
+            "end": 67,
+            "text": "Present",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "52101004",
+                    "cui": "C0150312",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 68,
+            "end": 75,
+            "text": "Illness",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "39104002",
+                    "cui": "C0221423",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T184"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 141,
+            "end": 148,
+            "text": "history",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "392521001",
+                    "cui": "C0262926",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 205,
+            "end": 223,
+            "text": "suspected covid-19",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "840544004",
+                    "cui": "C5203671",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 228,
+            "end": 242,
+            "text": "Social History",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "160476009",
+                    "cui": "C0424945",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 695,
+            "end": 704,
+            "text": "Complaint",
+            "polarity": -1,
+            "conceptAttributes": [
+                {
+                    "code": "33962009",
+                    "cui": "C0277786",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                },
+                {
+                    "code": "409586006",
+                    "cui": "C0277786",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 723,
+            "end": 730,
+            "text": "History",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "392521001",
+                    "cui": "C0262926",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 734,
+            "end": 741,
+            "text": "Present",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "52101004",
+                    "cui": "C0150312",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 742,
+            "end": 749,
+            "text": "Illness",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "39104002",
+                    "cui": "C0221423",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T184"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 814,
+            "end": 821,
+            "text": "history",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "392521001",
+                    "cui": "C0262926",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 878,
+            "end": 896,
+            "text": "suspected covid-19",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "840544004",
+                    "cui": "C5203671",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 901,
+            "end": 915,
+            "text": "Social History",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "160476009",
+                    "cui": "C0424945",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1351,
+            "end": 1360,
+            "text": "Complaint",
+            "polarity": -1,
+            "conceptAttributes": [
+                {
+                    "code": "409586006",
+                    "cui": "C0277786",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                },
+                {
+                    "code": "33962009",
+                    "cui": "C0277786",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1379,
+            "end": 1386,
+            "text": "History",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "392521001",
+                    "cui": "C0262926",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1390,
+            "end": 1397,
+            "text": "Present",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "52101004",
+                    "cui": "C0150312",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1398,
+            "end": 1405,
+            "text": "Illness",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "39104002",
+                    "cui": "C0221423",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T184"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1470,
+            "end": 1477,
+            "text": "history",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "392521001",
+                    "cui": "C0262926",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1537,
+            "end": 1551,
+            "text": "Social History",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "160476009",
+                    "cui": "C0424945",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1800,
+            "end": 1814,
+            "text": "sputum finding",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "248595008",
+                    "cui": "C0425511",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1826,
+            "end": 1833,
+            "text": "fatigue",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "84229001",
+                    "cui": "C0015672",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T184"
+                },
+                {
+                    "code": "248274002",
+                    "cui": "C0015672",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T184"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1845,
+            "end": 1850,
+            "text": "fever",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "386661006",
+                    "cui": "C0015967",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T184"
+                },
+                {
+                    "code": "50177009",
+                    "cui": "C0015967",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T184"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1862,
+            "end": 1875,
+            "text": "loss of taste",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "36955009",
+                    "cui": "C2364111",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T184"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1887,
+            "end": 1905,
+            "text": "suspected covid-19",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "840544004",
+                    "cui": "C5203671",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 1972,
+            "end": 1980,
+            "text": "physical",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "19388002",
+                    "cui": "C0205485",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T169"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2099,
+            "end": 2108,
+            "text": "Complaint",
+            "polarity": -1,
+            "conceptAttributes": [
+                {
+                    "code": "409586006",
+                    "cui": "C0277786",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                },
+                {
+                    "code": "33962009",
+                    "cui": "C0277786",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2127,
+            "end": 2134,
+            "text": "History",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "392521001",
+                    "cui": "C0262926",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2138,
+            "end": 2145,
+            "text": "Present",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "52101004",
+                    "cui": "C0150312",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2146,
+            "end": 2153,
+            "text": "Illness",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "39104002",
+                    "cui": "C0221423",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T184"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2218,
+            "end": 2225,
+            "text": "history",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "392521001",
+                    "cui": "C0262926",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2268,
+            "end": 2282,
+            "text": "Social History",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "160476009",
+                    "cui": "C0424945",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2678,
+            "end": 2686,
+            "text": "physical",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "19388002",
+                    "cui": "C0205485",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T169"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2728,
+            "end": 2737,
+            "text": "Complaint",
+            "polarity": -1,
+            "conceptAttributes": [
+                {
+                    "code": "409586006",
+                    "cui": "C0277786",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                },
+                {
+                    "code": "33962009",
+                    "cui": "C0277786",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2756,
+            "end": 2763,
+            "text": "History",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "392521001",
+                    "cui": "C0262926",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2767,
+            "end": 2774,
+            "text": "Present",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "52101004",
+                    "cui": "C0150312",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2775,
+            "end": 2782,
+            "text": "Illness",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "39104002",
+                    "cui": "C0221423",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T184"
+                }
+            ],
+            "type": "SignSymptomMention"
+        },
+        {
+            "begin": 2836,
+            "end": 2850,
+            "text": "Social History",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "160476009",
+                    "cui": "C0424945",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T033"
+                }
+            ],
+            "type": "SignSymptomMention"
+        }
+    ],
+    "IdentifiedAnnotation": [
+        {
+            "begin": 127,
+            "end": 134,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 215,
+            "end": 223,
+            "text": "covid-19",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "a0_4",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_72",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_19",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_18",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_39",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "SP_5",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_69",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 244,
+            "end": 251,
+            "text": "Patient",
+            "polarity": -1,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 272,
+            "end": 279,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 327,
+            "end": 334,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 491,
+            "end": 498,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 538,
+            "end": 547,
+            "text": "influenza",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "DIS_38",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 605,
+            "end": 615,
+            "text": "procedures",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "BMV_98",
+                    "codingScheme": "custom",
+                    "tui": "TC0184661"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 800,
+            "end": 807,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 888,
+            "end": 896,
+            "text": "covid-19",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "a0_4",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_72",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_19",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_18",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_39",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "SP_5",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_69",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 917,
+            "end": 924,
+            "text": "Patient",
+            "polarity": -1,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 945,
+            "end": 952,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1000,
+            "end": 1007,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1147,
+            "end": 1154,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1194,
+            "end": 1203,
+            "text": "influenza",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "DIS_38",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1261,
+            "end": 1271,
+            "text": "procedures",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "BMV_98",
+                    "codingScheme": "custom",
+                    "tui": "TC0184661"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1456,
+            "end": 1463,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1553,
+            "end": 1560,
+            "text": "Patient",
+            "polarity": -1,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1581,
+            "end": 1588,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1636,
+            "end": 1643,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1773,
+            "end": 1780,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1800,
+            "end": 1806,
+            "text": "sputum",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "DIS_62",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1826,
+            "end": 1833,
+            "text": "fatigue",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "DIS_29",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1845,
+            "end": 1850,
+            "text": "fever",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "a0_27",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "DIS_31",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_36",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1897,
+            "end": 1905,
+            "text": "covid-19",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "a0_4",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_72",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_19",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_18",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_39",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "SP_5",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                },
+                {
+                    "code": "n/a",
+                    "cui": "a0_69",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1932,
+            "end": 1942,
+            "text": "procedures",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "BMV_98",
+                    "codingScheme": "custom",
+                    "tui": "TC0184661"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1961,
+            "end": 1970,
+            "text": "face mask",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "a0_84",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 1993,
+            "end": 2000,
+            "text": "patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2029,
+            "end": 2047,
+            "text": "infectious disease",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "DIS_37",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2204,
+            "end": 2211,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2284,
+            "end": 2291,
+            "text": "Patient",
+            "polarity": -1,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2312,
+            "end": 2319,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2367,
+            "end": 2374,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2490,
+            "end": 2497,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2549,
+            "end": 2556,
+            "text": "patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2601,
+            "end": 2614,
+            "text": "acetaminophen",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "DIS_2",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2642,
+            "end": 2649,
+            "text": "patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2687,
+            "end": 2694,
+            "text": "therapy",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "BMV_126",
+                    "codingScheme": "custom",
+                    "tui": "TC0039798"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2852,
+            "end": 2859,
+            "text": "Patient",
+            "polarity": -1,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2880,
+            "end": 2887,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 2935,
+            "end": 2942,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        },
+        {
+            "begin": 3058,
+            "end": 3065,
+            "text": "Patient",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "n/a",
+                    "cui": "CE_64",
+                    "codingScheme": "custom",
+                    "tui": "T0NA"
+                }
+            ],
+            "type": "IdentifiedAnnotation"
+        }
+    ],
+    "ProcedureMention": [
+        {
+            "begin": 461,
+            "end": 471,
+            "text": "Assessment",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "386053000",
+                    "cui": "C1261322",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                },
+                {
+                    "code": "129265001",
+                    "cui": "C1261322",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                }
+            ],
+            "type": "ProcedureMention"
+        },
+        {
+            "begin": 634,
+            "end": 659,
+            "text": "medication reconciliation",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "430193006",
+                    "cui": "C2317067",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                }
+            ],
+            "type": "ProcedureMention"
+        },
+        {
+            "begin": 661,
+            "end": 670,
+            "text": "procedure",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "71388002",
+                    "cui": "C0184661",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T061"
+                }
+            ],
+            "type": "ProcedureMention"
+        },
+        {
+            "begin": 1117,
+            "end": 1127,
+            "text": "Assessment",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "386053000",
+                    "cui": "C1261322",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                },
+                {
+                    "code": "129265001",
+                    "cui": "C1261322",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                }
+            ],
+            "type": "ProcedureMention"
+        },
+        {
+            "begin": 1290,
+            "end": 1315,
+            "text": "medication reconciliation",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "430193006",
+                    "cui": "C2317067",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                }
+            ],
+            "type": "ProcedureMention"
+        },
+        {
+            "begin": 1317,
+            "end": 1326,
+            "text": "procedure",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "71388002",
+                    "cui": "C0184661",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T061"
+                }
+            ],
+            "type": "ProcedureMention"
+        },
+        {
+            "begin": 1753,
+            "end": 1763,
+            "text": "Assessment",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "386053000",
+                    "cui": "C1261322",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                },
+                {
+                    "code": "129265001",
+                    "cui": "C1261322",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                }
+            ],
+            "type": "ProcedureMention"
+        },
+        {
+            "begin": 2470,
+            "end": 2480,
+            "text": "Assessment",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "129265001",
+                    "cui": "C1261322",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                },
+                {
+                    "code": "386053000",
+                    "cui": "C1261322",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                }
+            ],
+            "type": "ProcedureMention"
+        },
+        {
+            "begin": 2678,
+            "end": 2704,
+            "text": "physical therapy procedure",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "91251008",
+                    "cui": "C0949766",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T061"
+                }
+            ],
+            "type": "ProcedureMention"
+        },
+        {
+            "begin": 3038,
+            "end": 3048,
+            "text": "Assessment",
+            "polarity": 0,
+            "conceptAttributes": [
+                {
+                    "code": "129265001",
+                    "cui": "C1261322",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                },
+                {
+                    "code": "386053000",
+                    "cui": "C1261322",
+                    "codingScheme": "SNOMEDCT_US",
+                    "tui": "T058"
+                }
+            ],
+            "type": "ProcedureMention"
+        }
+    ]
+}

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -22,12 +22,14 @@ class PathResource(Enum):
     PHYSICIAN_NOTE_TEXT = path('test_physician_note.txt')
     PHYSICIAN_NOTE_JSON = path('test_physician_note.json')
     SEMANTICS_BSV = path('semantics.bsv')
+    SYNTHETIC_JSON = path('synthetic.json')
     TEST_NEGATION = path('test_negation_hard.txt')
 
 
 class LoadResource(Enum):
     PHYSICIAN_NOTE_TEXT = load(PathResource.PHYSICIAN_NOTE_TEXT.value)
     PHYSICIAN_NOTE_JSON = load(PathResource.PHYSICIAN_NOTE_JSON.value)
+    SYNTHETIC_JSON = load(PathResource.SYNTHETIC_JSON.value)
     TEST_NEGATION = load(PathResource.TEST_NEGATION.value)
 
 

--- a/test/test_text2fhir.py
+++ b/test/test_text2fhir.py
@@ -1,0 +1,343 @@
+"""Tests for text2fhir.py"""
+
+import unittest
+
+import ctakesclient
+from ctakesclient import text2fhir
+from ctakesclient.typesystem import CtakesJSON, MatchText, Polarity
+
+from test.test_resources import LoadResource
+
+
+def expected_nlp_source() -> dict:
+    ver = ctakesclient.__version__
+    url = f'https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py/releases/tag/v{ver}'
+
+    return {
+        'url': 'http://fhir-registry.smarthealthit.org/StructureDefinition/nlp-source',
+        'extension': [
+            {'url': 'algorithm', 'valueString': 'ctakesclient'},
+            {'url': 'version', 'valueString': f'{url}'},
+        ],
+    }
+
+
+###############################################################################
+#
+# Unit Test : assertions and lightweight checking reading/printing FHIR types
+#
+###############################################################################
+
+class TestText2Fhir(unittest.TestCase):
+    """
+    Test Transformation from NLP results  to FHIR resources.
+    Test serialization to/from JSON of the different types (NLP and FHIR).
+    """
+    def setUp(self):
+        super().setUp()
+        self.ctakes = CtakesJSON(LoadResource.SYNTHETIC_JSON.value)
+        self.maxDiff = None  # For debugging. pylint: disable=invalid-name
+
+    def test_nlp_source(self):
+        expected = expected_nlp_source()
+        actual = text2fhir._nlp_source()  # pylint: disable=protected-access
+        # common.print_json(actual)
+        self.assertDictEqual(expected, actual.as_json())
+
+    def test_nlp_derivation_reference(self):
+        actual = text2fhir._nlp_derivation(docref_id='ABCD', offset=20, length=5)  # pylint: disable=protected-access
+        # common.print_json(actual)
+        self.assertDictEqual({
+            'url': 'http://hl7.org/fhir/StructureDefinition/derivation-reference',
+            'extension': [
+                {'url': 'reference', 'valueReference': {'reference': 'DocumentReference/ABCD'}},
+                {'url': 'offset', 'valueInteger': 20},
+                {'url': 'length', 'valueInteger': 5},
+            ],
+        }, actual.as_json())
+
+    def test_nlp_concept(self):
+        """
+        Test construction of FHIR CodeableConcept
+        """
+        match = self.ctakes.list_anatomical_site(Polarity.pos)[0]
+        bodysite = text2fhir.nlp_concept(match).as_json()
+
+        self.assertDictEqual({
+            'coding': [
+                {
+                    'code': '8205005',
+                    'system': 'http://snomed.info/sct',
+                },
+                {
+                    'code': 'C0043262',
+                    'system': 'http://terminology.hl7.org/CodeSystem/umls',
+                },
+            ],
+            'text': 'wrist',
+        }, bodysite)
+
+    def test_nlp_concept_unknown_vocab(self):
+        """
+        Confirm we gracefully handle unknown vocabularies
+        """
+        match = MatchText({
+            'conceptAttributes': [{
+                'code': 'foobar',
+                'codingScheme': 'custom',
+                'cui': 'C0043262',
+            }],
+            'polarity': 0,
+            'text': 'boo',
+            'type': 'AnatomicalSiteMention',
+        })
+        concept = text2fhir.nlp_concept(match).as_json()
+
+        self.assertDictEqual({
+            'coding': [
+                {
+                    'code': 'foobar',
+                },
+                {
+                    'code': 'C0043262',
+                    'system': 'http://terminology.hl7.org/CodeSystem/umls',
+                },
+            ],
+            'text': 'boo',
+        }, concept)
+
+    def test_nlp_condition(self):
+        """
+        Test conversion from NLP to FHIR (DiseaseDisorder -> FHIR Condition).
+        Test serialization to/from JSON.
+        Does not text expected values.
+        """
+        match = self.ctakes.list_disease_disorder()[0]
+        condition = text2fhir.nlp_condition('1234', '5678', 'ABCD', match).as_json()
+        del condition['id']  # randomly generated id
+
+        self.assertDictEqual({
+            'code': {
+                'coding': [
+                    {
+                        'code': '195662009',
+                        'system': 'http://snomed.info/sct',
+                    },
+                    {
+                        'code': 'C0396000',
+                        'system': 'http://terminology.hl7.org/CodeSystem/umls',
+                    },
+                ],
+                'text': 'acute viral pharyngitis',
+            },
+            'encounter': {
+                'reference': 'Encounter/5678',
+            },
+            'extension': [
+                {
+                    'extension': [
+                        {'url': 'reference', 'valueReference': {'reference': 'DocumentReference/ABCD'}},
+                        {'url': 'offset', 'valueInteger': 152},
+                        {'url': 'length', 'valueInteger': 23},
+                    ],
+                    'url': 'http://hl7.org/fhir/StructureDefinition/derivation-reference',
+                },
+            ],
+            'modifierExtension': [
+                expected_nlp_source(),
+                {
+                    'url': 'http://fhir-registry.smarthealthit.org/StructureDefinition/nlp-polarity',
+                    'valueBoolean': True,
+                },
+            ],
+            'resourceType': 'Condition',
+            'subject': {
+                'reference': 'Patient/1234',
+            },
+            'verificationStatus': {
+                'coding': [
+                    {
+                        'code': 'unconfirmed',
+                        'system': 'http://terminology.hl7.org/CodeSystem/condition-ver-status',
+                    },
+                ],
+                'text': 'Unconfirmed',
+            },
+        }, condition)
+
+    def test_nlp_medication(self):
+        """
+        Test conversion from NLP to FHIR (MedicationMention -> FHIR MedicationStatement).
+        Test serialization to/from JSON.
+        Does not text expected values.
+        """
+        match = self.ctakes.list_medication()[0]
+        medication = text2fhir.nlp_medication('1234', '5678', 'ABCD', match).as_json()
+        del medication['id']  # randomly generated id
+
+        self.assertDictEqual({
+            'context': {
+                'reference': 'Encounter/5678',
+            },
+            'medicationCodeableConcept': {
+                'coding': [
+                    {
+                        'code': '66076007',
+                        'system': 'http://snomed.info/sct',
+                    },
+                    {
+                        'code': 'C0304290',
+                        'system': 'http://terminology.hl7.org/CodeSystem/umls',
+                    },
+                    {
+                        'code': '91058',
+                        'system': 'http://www.nlm.nih.gov/research/umls/rxnorm',
+                    },
+                    {
+                        'code': 'C0304290',
+                        'system': 'http://terminology.hl7.org/CodeSystem/umls',
+                    },
+                ],
+                'text': 'chewable tablet',
+            },
+            'extension': [
+                {
+                    'extension': [
+                        {'url': 'reference', 'valueReference': {'reference': 'DocumentReference/ABCD'}},
+                        {'url': 'offset', 'valueInteger': 442},
+                        {'url': 'length', 'valueInteger': 15},
+                    ],
+                    'url': 'http://hl7.org/fhir/StructureDefinition/derivation-reference',
+                },
+            ],
+            'modifierExtension': [
+                expected_nlp_source(),
+                {
+                    'url': 'http://fhir-registry.smarthealthit.org/StructureDefinition/nlp-polarity',
+                    'valueBoolean': True,
+                },
+            ],
+            'resourceType': 'MedicationStatement',
+            'status': 'unknown',
+            'subject': {
+                'reference': 'Patient/1234',
+            },
+        }, medication)
+
+    def test_nlp_observation(self):
+        """
+        Test conversion from NLP to FHIR (SignSymptomMention -> FHIR Observation).
+        Test serialization to/from JSON.
+        Does not text expected values.
+        """
+        match = self.ctakes.list_sign_symptom()[0]
+        symptom = text2fhir.nlp_observation('1234', '5678', 'ABCD', match).as_json()
+        del symptom['id']  # randomly generated id
+
+        self.assertDictEqual({
+            'code': {
+                'coding': [
+                    {
+                        'code': '33962009',
+                        'system': 'http://snomed.info/sct',
+                    },
+                    {
+                        'code': 'C0277786',
+                        'system': 'http://terminology.hl7.org/CodeSystem/umls',
+                    },
+                    {
+                        'code': '409586006',
+                        'system': 'http://snomed.info/sct',
+                    },
+                    {
+                        'code': 'C0277786',
+                        'system': 'http://terminology.hl7.org/CodeSystem/umls',
+                    },
+                ],
+                'text': 'Complaint',
+            },
+            'encounter': {
+                'reference': 'Encounter/5678',
+            },
+            'extension': [
+                {
+                    'extension': [
+                        {'url': 'reference', 'valueReference': {'reference': 'DocumentReference/ABCD'}},
+                        {'url': 'offset', 'valueInteger': 21},
+                        {'url': 'length', 'valueInteger': 9},
+                    ],
+                    'url': 'http://hl7.org/fhir/StructureDefinition/derivation-reference',
+                },
+            ],
+            'modifierExtension': [
+                expected_nlp_source(),
+                {
+                    'url': 'http://fhir-registry.smarthealthit.org/StructureDefinition/nlp-polarity',
+                    'valueBoolean': False,
+                },
+            ],
+            'resourceType': 'Observation',
+            'status': 'preliminary',
+            'subject': {
+                'reference': 'Patient/1234',
+            },
+        }, symptom)
+
+    def test_nlp_procedure(self):
+        """
+        Test conversion from NLP to FHIR (Procedure -> FHIR Procedure).
+        Test serialization to/from JSON.
+        Does not text expected values.
+        """
+        match = self.ctakes.list_procedure()[0]
+        procedure = text2fhir.nlp_procedure('1234', '5678', 'ABCD', match).as_json()
+        del procedure['id']  # randomly generated id
+
+        self.assertDictEqual({
+            'code': {
+                'coding': [
+                    {
+                        'code': '129265001',
+                        'system': 'http://snomed.info/sct',
+                    },
+                    {
+                        'code': 'C1261322',
+                        'system': 'http://terminology.hl7.org/CodeSystem/umls',
+                    },
+                    {
+                        'code': '386053000',
+                        'system': 'http://snomed.info/sct',
+                    },
+                    {
+                        'code': 'C1261322',
+                        'system': 'http://terminology.hl7.org/CodeSystem/umls',
+                    },
+                ],
+                'text': 'Assessment',
+            },
+            'encounter': {
+                'reference': 'Encounter/5678',
+            },
+            'extension': [
+                {
+                    'extension': [
+                        {'url': 'reference', 'valueReference': {'reference': 'DocumentReference/ABCD'}},
+                        {'url': 'offset', 'valueInteger': 461},
+                        {'url': 'length', 'valueInteger': 10},
+                    ],
+                    'url': 'http://hl7.org/fhir/StructureDefinition/derivation-reference',
+                },
+            ],
+            'modifierExtension': [
+                expected_nlp_source(),
+                {
+                    'url': 'http://fhir-registry.smarthealthit.org/StructureDefinition/nlp-polarity',
+                    'valueBoolean': True,
+                },
+            ],
+            'resourceType': 'Procedure',
+            'status': 'unknown',
+            'subject': {
+                'reference': 'Patient/1234',
+            },
+        }, procedure)


### PR DESCRIPTION
- Adds some new methods in ctakesclient.text2fhir like nlp_condition or nlp_observation that take a ctakes MatchText and return a fhirclient resource for it.
- These returned resources include extensions for defining polarity, derivation span, and what source algorithm generated the NLP.

This only includes five new public methods:
- nlp_concept
- nlp_condition
- nlp_observation
- nlp_medication
- nlp_procedure

Each will take a `MatchText` and some other parameters and return a `fhirclient` resource. The id will be randomly generated.