### PR TITLE
build: drop support for Python 3.6, add support for 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,10 +4,10 @@ on: [push]
 jobs:
   unittest:
     name: unit tests
-    runs-on: ubuntu-20.04 # Can bump once we drop support for py3.6
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/ctakesclient/__init__.py
+++ b/ctakesclient/__init__.py
@@ -1,6 +1,6 @@
 """Public API"""
 
-__version__ = '1.3.1'
+__version__ = '2.0.0'
 
 from . import client
 from . import filesystem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [project]
 name = "ctakesclient"
-# We'll want to officially support 3.6 until we no longer care about CentOS 7
-requires-python = ">= 3.6"
+requires-python = ">= 3.7"
 dependencies = [
     "fhirclient >= 4.1",
     "requests",


### PR DESCRIPTION
3.6 is end-of-life and we only supported it for a moment in order to test in CentOS 7, but we no longer need that.

Meanwhile, 3.11 came out a few weeks ago, so let's test against that.

And bump version to 2.0.0 because of this breaking change.