### PR TITLE
ci: run the security static analysis tool bandit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,13 +35,18 @@ jobs:
       - name: Install linters
         run: |
           python -m pip install --upgrade pip
-          pip install pycodestyle pylint
+          pip install bandit[toml] pycodestyle pylint
 
       - name: Run pycodestyle
         run: |
           pycodestyle --max-line-length=120 .
 
       - name: Run pylint
-        if: success() || failure() # still run pylint if pycodestyle fails
+        if: success() || failure() # still run pylint if above checks fails
         run: |
           pylint ctakesclient/ scripts/* tests/
+
+      - name: Run bandit
+        if: success() || failure() # still run bandit if above checks fail
+        run: |
+          bandit -c pyproject.toml -r .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ include = [
     "LICENSE",
 ]
 
+[tool.bandit]
+exclude_dirs = ["tests"]
+
 [project.optional-dependencies]
 docs = [
     "myst-parser", # markdown support in sphinx


### PR DESCRIPTION
We talk to external services and are used in sensitive contexts, so it seems sensible to have some checks.

Nothing was detected currently, so this is just CI changes.