### PR TITLE
created text2fhir example TEXT and JSON per request of @tmills

### DIFF
--- a/ctakesclient/filesystem.py
+++ b/ctakesclient/filesystem.py
@@ -216,6 +216,10 @@ def read_json(filename) -> dict:
     with open(filename, 'r', encoding='utf-8') as fp:
         return json.load(fp)
 
+def write_json(filename, data: dict) -> None:
+    logging.info('write_json(%s)', filename)
+    with open(filename, 'w', encoding='utf-8') as fp:
+        json.dump(data, fp, indent=4)
 
 ###############################################################################
 #

--- a/ctakesclient/text2fhir.py
+++ b/ctakesclient/text2fhir.py
@@ -472,3 +472,20 @@ def nlp_fhir(
         as_fhir.append(nlp_procedure(subject_id, encounter_id, docref_id, match, source))
 
     return as_fhir
+
+def text2fhir(physician_note: str, polarity: Polarity = Polarity.pos) -> List[DomainResource]:
+    """
+    "all in one" method : Send TEXT get FHIR resources.
+    Note: see nlp_fhir for proper use of FHIR linked identifiers.
+    FHIR resource IDs are randomly generated and consistent for each physician_note
+
+    :param physician_note: raw clinical text (note or fragment)
+    :param polarity: filter only positive mentions by default
+    :return: List of FHIR Resources (DomainResource)
+    """
+    return nlp_fhir(subject_id=_random_id(),
+                    encounter_id=_random_id(),
+                    docref_id=_random_id(),
+                    nlp_results=ctakesclient.client.extract(physician_note),
+                    source=_nlp_source(),
+                    polarity=polarity)


### PR DESCRIPTION
@mikix this method existed at one time, I think in unit tests. 
I'm not sure where you would like this test example to exist. 
Maybe in getting started/ tutorial instead of tests? I'm happy with wherever it lives so long as we can point people at it. 

###############################################################
Changes: 

added example physician note TEXT and JSON response 
test_resources.py
test_text2fhir.py

added write_json method to save text2fhir results
filesystem.py

added "one stop shop" method for sending TEXT and getting FHIR. Randomly generates IDs. Mostly used for Getting Started Tutorials. text2fhir.py
test_text2fhir.py