### PR TITLE
feat: add filesystem.covid_symptoms_path to get bsv path directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project specific
 
+/.idea/
 example-output/
 example-phi-build/
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -432,6 +432,6 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=StandardError,
-                       Exception,
-                       BaseException
+overgeneral-exceptions=builtins.StandardError,
+                       builtins.Exception,
+                       builtins.BaseException

--- a/ctakesclient/__init__.py
+++ b/ctakesclient/__init__.py
@@ -1,6 +1,6 @@
 """Public API"""
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 from . import client
 from . import filesystem

--- a/ctakesclient/filesystem.py
+++ b/ctakesclient/filesystem.py
@@ -218,9 +218,19 @@ def _resource_file(filename: str) -> str:
     return os.path.join(os.path.dirname(__file__), "resources", filename)
 
 
+def covid_symptoms_path() -> str:
+    """Returns the path to a bsv file of covid symptoms"""
+    return _resource_file("covid_symptoms.bsv")
+
+
 def covid_symptoms() -> List[BsvConcept]:
     """Returns a list of known covid symptoms"""
-    return list_bsv_concept(_resource_file("covid_symptoms.bsv"))
+    return list_bsv_concept(covid_symptoms_path())
+
+
+def umls_semantic_groups_path() -> str:
+    """Returns the path to a bsv file of UMLS semantic groups"""
+    return _resource_file("SemGroups_2018.bsv")
 
 
 def umls_semantic_groups() -> List[BsvSemanticType]:
@@ -229,4 +239,4 @@ def umls_semantic_groups() -> List[BsvSemanticType]:
 
     See https://lhncbc.nlm.nih.gov/ii/tools/MetaMap/documentation/SemanticTypesAndGroups.html
     """
-    return list_bsv_semantics(_resource_file("SemGroups_2018.bsv"))
+    return list_bsv_semantics(umls_semantic_groups_path())

--- a/ctakesclient/text2fhir.py
+++ b/ctakesclient/text2fhir.py
@@ -237,7 +237,7 @@ def _nlp_polarity(polarity: Polarity) -> Extension:
 
 
 def _nlp_derivation_span(docref_id, span: Span) -> Extension:
-    return _nlp_derivation(docref_id=docref_id, offset=span.begin, length=(span.end - span.begin))
+    return _nlp_derivation(docref_id=docref_id, offset=span.begin, length=span.end - span.begin)
 
 
 def _nlp_derivation(docref_id, offset=None, length=None) -> Extension:

--- a/ctakesclient/typesystem.py
+++ b/ctakesclient/typesystem.py
@@ -137,7 +137,7 @@ class MatchText:
         elif polarity == 0:
             return Polarity.pos
         else:
-            raise Exception(f"polarity unknown: {polarity}")
+            raise ValueError(f"polarity unknown: {polarity}")
 
     @staticmethod
     def parse_mention(mention: str) -> UmlsTypeMention:

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,13 +1,29 @@
 """Tests for the filesystem module"""
 
+import os
 import unittest
+
+import ddt
 
 from ctakesclient import filesystem
 from tests.test_resources import PathResource
 
 
+@ddt.ddt
 class TestCovidSymptomsBSV(unittest.TestCase):
     """Test case for files loaded from bsv"""
+
+    @ddt.data(
+        filesystem.covid_symptoms_path,
+        filesystem.umls_semantic_groups_path,
+    )
+    def test_path_methods(self, method):
+        """Verify we hand out a bsv path correctly"""
+        path = method()
+        self.assertIsInstance(path, str)
+        self.assertTrue(path.endswith(".bsv"))
+        self.assertTrue(os.path.isabs(path))
+        self.assertTrue(os.path.isfile(path))
 
     def test_covid_symptom_concepts(self):
         """


### PR DESCRIPTION
(Also add umls_semantic_groups_path.)

filesystem.covid_symptoms() was intended to be the primary way to ask for the covid symptoms list, but there are also use cases where it's easiest to directly access the bsv file. So here it is.