### PR TITLE
fix(text2fhir): don't duplicate CUIs

### DIFF
--- a/ctakesclient/__init__.py
+++ b/ctakesclient/__init__.py
@@ -1,6 +1,6 @@
 """Public API"""
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 from . import client
 from . import filesystem

--- a/ctakesclient/text2fhir.py
+++ b/ctakesclient/text2fhir.py
@@ -290,9 +290,13 @@ def nlp_concept(match: MatchText) -> CodeableConcept:
     :return: FHIR CodeableConcept with both UMLS CUI and source vocab CODE
     """
     coded = []
+    cuis = set()
     for concept in match.conceptAttributes:
         coded.append(Coding({"system": _vocab_url(concept.codingScheme), "code": concept.code}))
-        coded.append(Coding({"system": Vocab.UMLS.value, "code": concept.cui}))
+        cuis.add(concept.cui)  # collect CUIs as a set, because they are often duplicated across vocab mentions
+
+    for cui in cuis:
+        coded.append(Coding({"system": Vocab.UMLS.value, "code": cui}))
 
     return CodeableConcept({"text": match.text, "coding": [c.as_json() for c in coded]})
 

--- a/tests/test_text2fhir.py
+++ b/tests/test_text2fhir.py
@@ -205,10 +205,6 @@ class TestText2Fhir(unittest.TestCase):
                             "system": "http://snomed.info/sct",
                         },
                         {
-                            "code": "C0304290",
-                            "system": "http://terminology.hl7.org/CodeSystem/umls",
-                        },
-                        {
                             "code": "91058",
                             "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
                         },
@@ -262,10 +258,6 @@ class TestText2Fhir(unittest.TestCase):
                         {
                             "code": "33962009",
                             "system": "http://snomed.info/sct",
-                        },
-                        {
-                            "code": "C0277786",
-                            "system": "http://terminology.hl7.org/CodeSystem/umls",
                         },
                         {
                             "code": "409586006",
@@ -324,10 +316,6 @@ class TestText2Fhir(unittest.TestCase):
                         {
                             "code": "129265001",
                             "system": "http://snomed.info/sct",
-                        },
-                        {
-                            "code": "C1261322",
-                            "system": "http://terminology.hl7.org/CodeSystem/umls",
                         },
                         {
                             "code": "386053000",


### PR DESCRIPTION
Collect CUIs in a set, to avoid repeating them unnecessarily.

Fixes #50