### PR TITLE
feat!: switch to async http request methods

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@ Clinical text fragment or entire physician note.
 
 ```python
 physician_note = 'Chief Complaint: Patient c/o cough, denies fever, recent COVID test negative. Denies smoking.'
-output = ctakesclient.client.post(physician_note)
+output = await ctakesclient.client.post(physician_note)
+```
+
+Note that `ctakesclient` uses an async API.
+If your code is not async, you can simply wrap calls in `asyncio.run()`:
+
+```python
+output = asyncio.run(ctakesclient.client.post(physician_note))
 ```
 
 # Output

--- a/ctakesclient/__init__.py
+++ b/ctakesclient/__init__.py
@@ -1,6 +1,6 @@
 """Public API"""
 
-__version__ = "2.1.1"
+__version__ = "3.0.0"
 
 from . import client
 from . import filesystem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "ctakesclient"
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 dependencies = [
     "fhirclient >= 4.1",
-    "requests",
+    "httpx",
 ]
 authors = [
   { name="Andy McMurry, PhD", email="andrew.mcmurry@childrens.harvard.edu" },
@@ -51,6 +51,7 @@ docs = [
 tests = [
     "ddt",
     "pytest",
+    "respx",
 ]
 dev = [
     "pre-commit"

--- a/tests/integration/test_client_ctakes_rest_server.py
+++ b/tests/integration/test_client_ctakes_rest_server.py
@@ -5,10 +5,10 @@ import ctakesclient
 from tests.test_resources import LoadResource
 
 
-class TestClientCtakesRestServer(unittest.TestCase):
+class TestClientCtakesRestServer(unittest.IsolatedAsyncioTestCase):
     """Test case for REST requests"""
 
-    def test_physician_note(self):
+    async def test_physician_note(self):
         """
         Test calling REST server returns JSON that matches expected.
         Strong typing (Polarity, MatchText, UmlsConcept) enforced during
@@ -17,18 +17,18 @@ class TestClientCtakesRestServer(unittest.TestCase):
         physician_note = LoadResource.PHYSICIAN_NOTE_TEXT.value
         expected = LoadResource.PHYSICIAN_NOTE_JSON.value
 
-        actual1 = ctakesclient.client.extract(physician_note).as_json()
-        actual2 = ctakesclient.client.extract(physician_note).as_json()
+        actual1 = (await ctakesclient.client.extract(physician_note)).as_json()
+        actual2 = (await ctakesclient.client.extract(physician_note)).as_json()
 
         unittest.TestCase.maxDiff = None
 
         self.assertDictEqual(expected, actual1, "JSON did not match round trip serialization")
         self.assertDictEqual(actual1, actual2, "calling service twice produces same results")
 
-    def test_unicode(self):
+    async def test_unicode(self):
         """Ensure that we handle utf8/unicode correctly"""
         # First, make sure we don't blow up just by sending it
-        ner = ctakesclient.client.extract("patient feels 🤒 with fever")
+        ner = await ctakesclient.client.extract("patient feels 🤒 with fever")
 
         # Then confirm that our spans are correct (0-based and character-based)
         self.assertLess(0, len(ner.list_sign_symptom()))

--- a/tests/integration/test_negation.py
+++ b/tests/integration/test_negation.py
@@ -30,13 +30,13 @@ def pretty(result: dict) -> str:
     return json.dumps(result, indent=4)
 
 
-class TestNegationCtakesDefaultContext(unittest.TestCase):
+class TestNegationCtakesDefaultContext(unittest.IsolatedAsyncioTestCase):
     """
     https://cwiki.apache.org/confluence/display/CTAKES/cTAKES+3.0+-+NE+Contexts
     """
 
-    def test_ctakes_covid_symptoms(self):
-        ner = ctakesclient.client.extract(note_negated_ros_review_of_symptoms())
+    async def test_ctakes_covid_symptoms(self):
+        ner = await ctakesclient.client.extract(note_negated_ros_review_of_symptoms())
 
         symptoms_dict = ctakesclient.filesystem.covid_symptoms()
         symptoms_fp = []
@@ -54,20 +54,20 @@ class TestNegationCtakesDefaultContext(unittest.TestCase):
 
     # pylint: disable-next=line-too-long
     @unittest.skip("https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py/issues/8")
-    def test_patient_denies(self):
+    async def test_patient_denies(self):
         """
         Test everything in this example note is negated.
         Unfortunately ctakes negation algorithm is not perfect.
         See linked issue above.
         """
         text = note_negated_denies()
-        ner = ctakesclient.client.extract(text)
+        ner = await ctakesclient.client.extract(text)
         false_positives = ner.list_match_text(Polarity.pos)
         self.assertEqual([], false_positives)
 
-    def test_history_of_headache(self):
+    async def test_history_of_headache(self):
         text = note_positive_headache()
-        ner = ctakesclient.client.extract(text)
+        ner = await ctakesclient.client.extract(text)
         self.assertIn("headache", ner.list_match_text())
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,13 +4,15 @@ import os
 import unittest
 from unittest import mock
 
+import respx
+
 from ctakesclient import client
 from ctakesclient.typesystem import Polarity
 
 from tests.test_resources import LoadResource
 
 
-class TestClient(unittest.TestCase):
+class TestClient(unittest.IsolatedAsyncioTestCase):
     """Test case for client cTAKES extraction"""
 
     @mock.patch.dict(os.environ, {"URL_CTAKES_REST": ""})
@@ -21,13 +23,20 @@ class TestClient(unittest.TestCase):
     def test_server_url_override(self):
         self.assertEqual(client.get_url_ctakes_rest(), "http://example.com:2002/blarg")
 
-    @mock.patch("ctakesclient.client.requests.post")
-    def test_simple_extract(self, mock_post):
+    @respx.mock
+    async def test_simple_extract(self):
         """Confirm that a call to extract() gives us the expected CtakesJSON object"""
-        mock_response = mock.MagicMock()
-        mock_response.json.return_value = LoadResource.PHYSICIAN_NOTE_JSON.value
-        mock_post.return_value = mock_response
-        ner = client.extract("input text does not matter")
+        sentence = "input text sentence"
+
+        # Prepare mocked response
+        respx.post(
+            "http://localhost:8080/ctakes-web-rest/service/analyze",
+            headers={"Content-Type": "text/plain; charset=UTF-8"},
+            content=sentence,
+        ).respond(json=LoadResource.PHYSICIAN_NOTE_JSON.value)
+
+        # Make the actual call
+        ner = await client.extract(sentence)
 
         # CtakesJSON is tested more fully in test_typesystem.py.
         # We just want to make sure that we did actually load the json here.

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -4,10 +4,13 @@ import os
 import unittest
 from unittest import mock
 
+import respx
+
 from ctakesclient import transformer
+from ctakesclient.typesystem import Polarity
 
 
-class TestTransformer(unittest.TestCase):
+class TestTransformer(unittest.IsolatedAsyncioTestCase):
     """Test case for client cNLP extraction"""
 
     @mock.patch.dict(os.environ, {"URL_CNLP_NEGATION": ""})
@@ -17,3 +20,26 @@ class TestTransformer(unittest.TestCase):
     @mock.patch.dict(os.environ, {"URL_CNLP_NEGATION": "http://example.com:2002/cnlp"})
     def test_server_url_override(self):
         self.assertEqual(transformer.get_url_cnlp_negation(), "http://example.com:2002/cnlp")
+
+    @respx.mock
+    async def test_map_polarity(self):
+        """Confirm that a basic call to map_polarity() works"""
+        sentence = "input text sentence"
+        spans = [(3, 5), (8, 13)]
+
+        # Prepare mocked response
+        respx.post(
+            "http://localhost:8000/negation/process",
+            json={"doc_text": sentence, "entities": spans},
+        ).respond(json={"statuses": [1, -1]})
+
+        # Make the actual call
+        results = await transformer.map_polarity(sentence, spans)
+
+        self.assertEqual(
+            {
+                (3, 5): Polarity.neg,
+                (8, 13): Polarity.pos,
+            },
+            results,
+        )


### PR DESCRIPTION
This changes the following API methods to be async:
- client.post
- client.extract
- transformer.list_polarity
- transformer.map_polarity

They all also take an optional client parameter, to specify an httpx.AsyncClient.

Version has been bumped to 3.0.0, as this is a major breaking change.