### PR TITLE
Bump version to 4.0

### DIFF
--- a/ctakesclient/__init__.py
+++ b/ctakesclient/__init__.py
@@ -1,6 +1,6 @@
 """Public API"""
 
-__version__ = "3.0.0"
+__version__ = "4.0.0"
 
 from . import client
 from . import filesystem


### PR DESCRIPTION
We've changed the icd10 codes since the last release, and that could affect NLP downstream. So to allow any consumers to react to the changed codes, let's bump the major version number.