### PR TITLE
feat: add ability to list polarity against the termexists model too

### DIFF
--- a/ctakesclient/__init__.py
+++ b/ctakesclient/__init__.py
@@ -1,6 +1,6 @@
 """Public API"""
 
-__version__ = "5.0.0"
+__version__ = "5.1.0"
 
 from . import client
 from . import filesystem

--- a/ctakesclient/transformer.py
+++ b/ctakesclient/transformer.py
@@ -1,5 +1,18 @@
-"""HTTP client for medical language"""
+"""
+Use cNLP transformers to detect polarity of specific words in text.
 
+For example, you might have cTAKES results, but want to know the difference between
+"the patient has a cough" and "the patient does not have a cough".
+In the former, the word cough has a positive polarity, in the latter a negative polarity.
+
+cTAKES has some built-in negation ability, but it's not perfect.
+These transformer models perform a bit better.
+
+We offer multiple polarity detection models.
+See: https://github.com/Machine-Learning-for-Medical-Language/cnlp_transformers
+"""
+
+import enum
 import os
 from typing import List, Tuple
 
@@ -8,11 +21,11 @@ import httpx
 from ctakesclient.exceptions import ClientError
 from ctakesclient.typesystem import Polarity
 
-###############################################################################
-#
-# https://github.com/Machine-Learning-for-Medical-Language/cnlp_transformers#negation-api
-#
-###############################################################################
+
+class TransformerModel(enum.Enum):
+    # Use the cnlpt model slug as a value, in case that's convenient for any consumers
+    NEGATION = "negation"
+    TERM_EXISTS = "termexists"
 
 
 def get_url_cnlp_negation() -> str:
@@ -25,18 +38,45 @@ def get_url_cnlp_negation() -> str:
     return url or "http://localhost:8000/negation/process"
 
 
+def get_url_cnlp_term_exists() -> str:
+    """
+    Grabs the URL for the termexists model.
+
+    https://github.com/Machine-Learning-for-Medical-Language/cnlp_transformers/blob/main/src/cnlpt/api/termexists_rest.py
+
+    :return: CTAKES_URL_TERM_EXISTS env variable or default using localhost
+    """
+    url = os.environ.get("URL_CNLP_TERM_EXISTS")
+    return url or "http://localhost:8000/termexists/process"
+
+
 async def list_polarity(
-    sentence: str, spans: List[Tuple[int, int]], url: str = None, client: httpx.AsyncClient = None
+    sentence: str,
+    spans: List[Tuple[int, int]],
+    url: str = None,
+    client: httpx.AsyncClient = None,
+    model: TransformerModel = TransformerModel.NEGATION,
 ) -> List[Polarity]:
     """
     :param sentence: clinical text to send to cTAKES
     :param spans: list of spans where each span is a tuple of (begin,end)
     :param url: Clinical NLP Transformer: Negation API
     :param client: optional existing HTTPX client session
+    :param model: which transformer model to use
     :return: List of Polarity (positive or negated)
     """
-    url = url or get_url_cnlp_negation()
     client = client or httpx.AsyncClient()
+
+    if model == TransformerModel.NEGATION:
+        pos_status = -1  # NOT negated (double negative)
+        neg_status = 1  # negated
+        url = url or get_url_cnlp_negation()
+    elif model == TransformerModel.TERM_EXISTS:
+        pos_status = 1
+        neg_status = -1
+        url = url or get_url_cnlp_term_exists()
+    else:
+        raise ValueError(f"Transformer model '{model.value}' not recognized.")
 
     doc = {"doc_text": sentence, "entities": spans}
     response = await client.post(url=url, json=doc)
@@ -45,11 +85,9 @@ async def list_polarity(
     polarities = []
 
     for status in response["statuses"]:
-        # NOT negated (double negative)
-        if status == -1:
+        if status == pos_status:
             polarities.append(Polarity.pos)
-        # Negated
-        elif status == 1:
+        elif status == neg_status:
             polarities.append(Polarity.neg)
         else:
             raise ClientError(f"negate-api unknown {status}, url= {url}")
@@ -61,14 +99,19 @@ async def list_polarity(
 
 
 async def map_polarity(
-    sentence: str, spans: List[Tuple[int, int]], url: str = None, client: httpx.AsyncClient = None
+    sentence: str,
+    spans: List[Tuple[int, int]],
+    url: str = None,
+    client: httpx.AsyncClient = None,
+    model: TransformerModel = TransformerModel.NEGATION,
 ) -> dict:
     """
     :param sentence: clinical text to send to cTAKES
     :param spans: list of spans where each span is a tuple of (begin,end)
     :param url: Clinical NLP Transformer: Negation API
     :param client: optional existing HTTPX client session
+    :param model: which transformer model to use
     :return: Map of Polarity key=span, value=polarity
     """
-    polarities = await list_polarity(sentence, spans, url=url, client=client)
+    polarities = await list_polarity(sentence, spans, url=url, client=client, model=model)
     return dict(zip(spans, polarities))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,9 @@ def is_port_open(port: int) -> bool:
 
 
 ctakes_port = 8080
-cnlp_port = 8000
-servers_are_running = is_port_open(ctakes_port) and is_port_open(cnlp_port)
+negation_port = 8000
+term_exists_port = 8001
+servers_are_running = is_port_open(ctakes_port) and is_port_open(negation_port) and is_port_open(term_exists_port)
 
 
 def pytest_addoption(parser):

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -14,16 +14,24 @@ class TestTransformer(unittest.IsolatedAsyncioTestCase):
     """Test case for client cNLP extraction"""
 
     @mock.patch.dict(os.environ, {"URL_CNLP_NEGATION": ""})
-    def test_server_url_default(self):
+    def test_negation_url_default(self):
         self.assertEqual(transformer.get_url_cnlp_negation(), "http://localhost:8000/negation/process")
 
     @mock.patch.dict(os.environ, {"URL_CNLP_NEGATION": "http://example.com:2002/cnlp"})
-    def test_server_url_override(self):
+    def test_negation_url_override(self):
         self.assertEqual(transformer.get_url_cnlp_negation(), "http://example.com:2002/cnlp")
 
+    @mock.patch.dict(os.environ, {"URL_CNLP_TERM_EXISTS": ""})
+    def test_term_exists_url_default(self):
+        self.assertEqual(transformer.get_url_cnlp_term_exists(), "http://localhost:8000/termexists/process")
+
+    @mock.patch.dict(os.environ, {"URL_CNLP_TERM_EXISTS": "http://example.com:2003/cnlp"})
+    def test_term_exists_url_override(self):
+        self.assertEqual(transformer.get_url_cnlp_term_exists(), "http://example.com:2003/cnlp")
+
     @respx.mock
-    async def test_map_polarity(self):
-        """Confirm that a basic call to map_polarity() works"""
+    async def test_negation_polarity(self):
+        """Confirm that a basic call to map_polarity() works with the default negation model"""
         sentence = "input text sentence"
         spans = [(3, 5), (8, 13)]
 
@@ -35,6 +43,29 @@ class TestTransformer(unittest.IsolatedAsyncioTestCase):
 
         # Make the actual call
         results = await transformer.map_polarity(sentence, spans)
+
+        self.assertEqual(
+            {
+                (3, 5): Polarity.neg,
+                (8, 13): Polarity.pos,
+            },
+            results,
+        )
+
+    @respx.mock
+    async def test_term_exists_polarity(self):
+        """Confirm that a basic call to map_polarity() works with the term exists model"""
+        sentence = "input text sentence"
+        spans = [(3, 5), (8, 13)]
+
+        # Prepare mocked response
+        respx.post(
+            "http://localhost:8000/termexists/process",
+            json={"doc_text": sentence, "entities": spans},
+        ).respond(json={"statuses": [-1, 1]})
+
+        # Make the actual call
+        results = await transformer.map_polarity(sentence, spans, model=transformer.TransformerModel.TERM_EXISTS)
 
         self.assertEqual(
             {


### PR DESCRIPTION
Previously, you could only check polarity using the negation cnlp transformer. But this commit adds the option to pass the specific model you want to list_polarity(). Currently, only negation (the default) and termexists are supported.