### PR TITLE
ci: switch to PyPI trusted publishing instead of api tokens

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -7,6 +7,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-22.04
+
+    permissions:
+      id-token: write # this permission is required for PyPI "trusted publishing"
+
     steps:
     - uses: actions/checkout@v3
 
@@ -20,6 +24,3 @@ jobs:
 
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        print_hash: true


### PR DESCRIPTION
This is a thing I just found out that PyPI supports. [Blog entry here](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) about it.

On the PyPI side, you can say "this specific github repo and workflow file can publish this package" and then the workflow gets a short-lived token.

So no more long-lived API tokens and they don't need to be tied to a PyPI user but rather the permissions/config is stored on the package itself.