### PR TITLE
ci: add a coverage check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,42 +1,54 @@
 name: CI
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   unittest:
     name: unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
           pip install .[tests]
 
       - name: Test with pytest
         run: |
-          python -m pytest
+          python -m pytest --cov=ctakesclient --cov-report=xml
+
+      - name: Check coverage report
+        if: github.ref != 'refs/heads/main'
+        uses: orgoro/coverage@v3.1
+        with:
+          coverageFile: coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          thresholdAll: .9
+          thresholdNew: 1
+          thresholdModified: 1
 
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install linters
-        #black is synced with the .pre-commit-hooks version
         run: |
           python -m pip install --upgrade pip
-          pip install bandit[toml] pycodestyle pylint black==22.12.0
+          pip install .[dev]
 
       - name: Run pycodestyle
         run: |

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -6,13 +6,13 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     permissions:
       id-token: write # this permission is required for PyPI "trusted publishing"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    #this version is synced with the black mentioned in .github/workflows/ci.yml
-    rev: 22.12.0
+    rev: 22.12.0  # keep in rough sync with pyproject.toml
     hooks:
       - id: black
         entry: bash -c 'black "$@"; git add -u' --
@@ -9,4 +8,4 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.11
+        language_version: python3.12

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,6 +4,7 @@
 #   public description of their style guide using 4)
 # - max-line-length changed to 120 because 80 was driving us crazy
 # - wrong-import-order re-enabled, because MT likes order among chaos
+# - disable cyclic-import check because it often has false positives
 #
 # BELOW THIS LINE IS A COPY OF https://google.github.io/styleguide/pylintrc
 
@@ -73,6 +74,7 @@ disable=abstract-method,
         cmp-method,
         coerce-builtin,
         coerce-method,
+        cyclic-import,
         delslice-method,
         div-method,
         duplicate-code,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,13 @@ docs = [
 tests = [
     "ddt",
     "pytest",
+    "pytest-cov",
     "respx",
 ]
 dev = [
-    "pre-commit"
+    "bandit[toml]",
+    "black >= 22, < 23",  # keep in rough sync with .pre-commit-config.yaml
+    "pre-commit",
+    "pycodestyle",
+    "pylint",
 ]


### PR DESCRIPTION
Pin at 90% (the current coverage) but only allow 100% on new/changed code to ratchet coverage upward.

Also:
- Support Python 3.12 in CI
- Modernize some github actions